### PR TITLE
Sagi/host iface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ build:
 build/discovery-client: GO_FILES=$(shell find discovery-client pkg -name '*.go')
 build/discovery-client: build $(GO_FILES)
 	$(GO_VARS) go build -o ./build/discovery-client $(DISCOVERY_CLIENT_PKG)
+	sudo setcap cap_net_raw+ep ./build/discovery-client
 
 clean:
 	$(Q) rm -f build/discovery-client

--- a/application/app.go
+++ b/application/app.go
@@ -77,7 +77,7 @@ func (app *App) Start() error {
 	}
 	app.cache = clientconfig.NewCache(app.ctx, app.cfg.ClientConfigDir, app.cfg.InternalDir, &app.cfg.AutoDetectEntries)
 	hostAPI := nvmehost.NewHostApi(app.cfg.LogPagePaginationEnabled, app.cfg.NvmeHostIDPath)
-	app.svc = service.NewService(app.ctx, app.cache, hostAPI, app.cfg.ReconnectInterval, app.cfg.MaxIOQueues)
+	app.svc = service.NewService(app.ctx, app.cache, hostAPI, app.cfg.ReconnectInterval, app.cfg.MaxIOQueues, app.cfg.DefaultHostIface)
 	if err := app.svc.Start(); err != nil {
 		return err
 	}

--- a/cmd/add_hostnqn.go
+++ b/cmd/add_hostnqn.go
@@ -42,6 +42,7 @@ func newAddHostNqnCmd() *cobra.Command {
 	cmd.Flags().StringP("hostnqn", "q", "", "host nqn")
 	cmd.Flags().StringP("nqn", "n", "", "subsystem nqn")
 	cmd.Flags().StringP("transport", "t", "tcp", "transport name - default to tcp")
+	cmd.Flags().StringP("host-iface", "f", "", "host iface to use")
 
 	return cmd
 }
@@ -81,8 +82,9 @@ func addHostNqnCmdFunc(cmd *cobra.Command, args []string) error {
 	nqn, err := cmd.Flags().GetString("nqn")
 	transport, err := cmd.Flags().GetString("transport")
 	addresses, err := cmd.Flags().GetStringSlice("addresses")
+	host_iface, err := cmd.Flags().GetString("host-iface")
 
-	entries, err := clientconfig.CreateEntries(addresses, hostnqn, nqn, transport)
+	entries, err := clientconfig.CreateEntries(addresses, hostnqn, nqn, transport, host_iface)
 	if err != nil {
 		return err
 	}

--- a/cmd/connect-all.go
+++ b/cmd/connect-all.go
@@ -48,6 +48,9 @@ func newConnectAllCmd() *cobra.Command {
 	cmd.Flags().StringP("host-traddr", "w", "", "host-traddr")
 	viper.BindPFlag("connect-all.host-traddr", cmd.Flags().Lookup("host-traddr"))
 
+	cmd.Flags().StringP("host-iface", "f", "", "host-iface")
+	viper.BindPFlag("connect-all.host-iface", cmd.Flags().Lookup("host-iface"))
+
 	cmd.Flags().BoolP("persistant", "p", false, "persistant")
 	viper.BindPFlag("connect-all.persistant", cmd.Flags().Lookup("persistant"))
 
@@ -68,6 +71,7 @@ func connectAllCmdFunc(cmd *cobra.Command, args []string) error {
 		Kato:      kato,
 		Hostnqn:   viper.GetString("connect-all.hostnqn"),
 		Transport: viper.GetString("connect-all.transport"),
+		HostIface: viper.GetString("connect-all.host-iface"),
 	}
 	ctrls, err := nvmeclient.ConnectAll(entry, viper.GetInt("connect-all.max-queues"))
 	if err != nil {

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -49,6 +49,9 @@ specified by the --nqn option.`,
 	cmd.Flags().StringP("host-traddr", "w", "", "host-traddr")
 	viper.BindPFlag("connect.host-traddr", cmd.Flags().Lookup("host-traddr"))
 
+	cmd.Flags().StringP("host-iface", "f", "", "host-iface")
+	viper.BindPFlag("connect.host-iface", cmd.Flags().Lookup("host-iface"))
+
 	cmd.Flags().StringP("nqn", "n", "", "nqn")
 	viper.BindPFlag("connect.nqn", cmd.Flags().Lookup("nqn"))
 
@@ -73,6 +76,7 @@ func connectCmdFunc(cmd *cobra.Command, args []string) error {
 		Hostnqn:     viper.GetString("connect.hostnqn"),
 		Transport:   viper.GetString("connect.transport"),
 		CtrlLossTMO: viper.GetInt("connect.ctrl-loss-tmo"),
+		HostIface:   viper.GetString("connect.host-iface"),
 	}
 	ctrlID, err := nvmeclient.Connect(request)
 	if err != nil {

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -48,6 +48,9 @@ func newDiscoverCmd() *cobra.Command {
 	cmd.Flags().StringP("host-traddr", "w", "", "host-traddr")
 	viper.BindPFlag("discover.host-traddr", cmd.Flags().Lookup("host-traddr"))
 
+	cmd.Flags().StringP("host-iface", "f", "", "host-iface")
+	viper.BindPFlag("discover.host-iface", cmd.Flags().Lookup("host-iface"))
+
 	cmd.Flags().BoolP("persistant", "p", false, "persistant")
 	viper.BindPFlag("discover.persistant", cmd.Flags().Lookup("persistant"))
 
@@ -71,6 +74,7 @@ func discoverCmdFunc(cmd *cobra.Command, args []string) error {
 		Kato:      katoValue,
 		Hostnqn:   viper.GetString("discover.hostnqn"),
 		Transport: viper.GetString("discover.transport"),
+		HostIface: viper.GetString("discover.host-iface"),
 	}
 
 	hostAPI := nvmehost.NewHostApi(true, "/etc/nvme/hostid")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -79,6 +79,9 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().Int("maxIOQueues", 0, "Overrides the default number of I/O queues create by the driver. Zero value means no override (default driver value is number of cores).")
 	viper.BindPFlag("maxIOQueues", cmd.Flags().Lookup("maxIOQueues"))
 
+	cmd.Flags().String("defaultHostIface", "", "default interface the discovery client and nvme driver will bind to when connecting to nvme endpoints")
+	viper.BindPFlag("defaultHostIface", cmd.Flags().Lookup("defaultHostIface"))
+
 	// auto detect configuration
 	cmd.Flags().BoolP("autoDetectEntries.enabled", "e", true, "should we detect")
 	viper.BindPFlag("autoDetectEntries.enabled", cmd.Flags().Lookup("autoDetectEntries.enabled"))

--- a/etc/discovery-client/discovery-client.yaml
+++ b/etc/discovery-client/discovery-client.yaml
@@ -4,6 +4,7 @@ internalDir: /etc/discovery-client/internal/
 reconnectInterval: 5s
 logPagePaginationEnabled: false
 maxIOQueues: 0
+defaultHostIface: ""
 nvmeHostIDPath: /tmp/discovery-client/hostid
 logging:
   filename: "/var/log/discovery-client.log"

--- a/model/app_config.go
+++ b/model/app_config.go
@@ -51,6 +51,7 @@ type AppConfig struct {
 	MaxIOQueues              int               `yaml:"maxIOQueues"`
 	AutoDetectEntries        AutoDetectEntries `yaml:"autoDetectEntries,omitempty"`
 	NvmeHostIDPath           string            `yaml:"nvmeHostIDPath,omitempty"`
+	HostIface                string            `yaml:"hostIface,omitempty"`
 }
 
 func (cfg *AppConfig) verifyConfigurationIsValid() error {

--- a/model/app_config.go
+++ b/model/app_config.go
@@ -51,7 +51,7 @@ type AppConfig struct {
 	MaxIOQueues              int               `yaml:"maxIOQueues"`
 	AutoDetectEntries        AutoDetectEntries `yaml:"autoDetectEntries,omitempty"`
 	NvmeHostIDPath           string            `yaml:"nvmeHostIDPath,omitempty"`
-	HostIface                string            `yaml:"hostIface,omitempty"`
+	DefaultHostIface         string            `yaml:"defaultHostIface,omitempty"`
 }
 
 func (cfg *AppConfig) verifyConfigurationIsValid() error {

--- a/pkg/clientconfig/conf_parser.go
+++ b/pkg/clientconfig/conf_parser.go
@@ -40,6 +40,7 @@ type Entry struct {
 	Subsysnqn  string
 	Persistent bool
 	Hostaddr   string
+	HostIface  string
 }
 
 func (e *Entry) compare(other *Entry) bool {
@@ -158,6 +159,9 @@ func parse(filename string) ([]*Entry, error) {
 			case "-n", "--subsysnqn":
 				i++
 				e.Subsysnqn = strings.TrimSpace(s[i])
+			case "-f", "--host-iface":
+				i++
+				e.HostIface = strings.TrimSpace(s[i])
 			case "-p", "--persistent":
 				e.Persistent = true
 			default:

--- a/pkg/commonstructs/common_structs.go
+++ b/pkg/commonstructs/common_structs.go
@@ -25,10 +25,15 @@ type Entry struct {
 	Trsvcid   int
 	Hostnqn   string
 	Nqn       string
+	HostIface string
 }
 
 func (entry *Entry) String() string {
-	return fmt.Sprintf("-t %s -a %s -s %d -q %s -n %s\n", entry.Transport, entry.Traddr, entry.Trsvcid, entry.Hostnqn, entry.Nqn)
+	host_iface := ""
+	if len(entry.HostIface) > 0 {
+		host_iface = fmt.Sprintf("-f %s", entry.HostIface)
+	}
+	return fmt.Sprintf("-t %s -a %s -s %d -q %s -n %s %s\n", entry.Transport, entry.Traddr, entry.Trsvcid, entry.Hostnqn, entry.Nqn, host_iface)
 }
 
 func EntriesToString(entries []*Entry) string {

--- a/pkg/hostapi/host_api.go
+++ b/pkg/hostapi/host_api.go
@@ -35,6 +35,7 @@ type DiscoverRequest struct {
 	Hostaddr  string
 	Kato      time.Duration //keep alive timeout. 0 value signifies request for non persistant connection
 	AENChan   chan AENStruct
+	HostIface string
 }
 
 // NvmeDiscPageEntry struct represent discovery log page that will be returned from discover method
@@ -78,6 +79,9 @@ func (c *DiscoverRequest) ToOptions() string {
 	}
 	if len(c.Hostaddr) > 0 {
 		sb.WriteString(fmt.Sprintf(",host_traddr=%s", c.Hostaddr))
+	}
+	if len(c.HostIface) > 0 {
+		sb.WriteString(fmt.Sprintf(",host_iface=%s", c.HostIface))
 	}
 	if c.Kato > 0 {
 		sb.WriteString(fmt.Sprintf(",keep_alive_tmo=%d", c.Kato))

--- a/pkg/nvme/nvmehost/nvmehost_impl.go
+++ b/pkg/nvme/nvmehost/nvmehost_impl.go
@@ -181,6 +181,7 @@ func createDiscoveryRequest(discoveryRequest *hostapi.DiscoverRequest) *Discover
 		Hostnqn:   discoveryRequest.Hostnqn,
 		Hostaddr:  discoveryRequest.Hostaddr,
 		Kato:      discoveryRequest.Kato,
+		HostIface: discoveryRequest.HostIface,
 	}
 }
 

--- a/pkg/nvmeclient/nvme_client.go
+++ b/pkg/nvmeclient/nvme_client.go
@@ -103,6 +103,7 @@ type ConnectRequest struct {
 	Subsysnqn   string
 	CtrlLossTMO int
 	MaxIOQueues int
+	HostIface   string
 }
 
 // ToOptions returns a comma delimited key=value string
@@ -124,6 +125,9 @@ func (c *ConnectRequest) ToOptions() string {
 	}
 	if len(c.Hostaddr) > 0 {
 		sb.WriteString(fmt.Sprintf(",host_traddr=%s", c.Hostaddr))
+	}
+	if len(c.HostIface) > 0 {
+		sb.WriteString(fmt.Sprintf(",host_iface=%s", c.HostIface))
 	}
 	if c.CtrlLossTMO >= -1 {
 		sb.WriteString(fmt.Sprintf(",ctrl_loss_tmo=%d", c.CtrlLossTMO))
@@ -491,11 +495,11 @@ func ConnectAll(discoveryRequest *hostapi.DiscoverRequest, maxIOQueues int) ([]*
 	if err != nil {
 		return nil, err
 	}
-	ctrls := ConnectAllNVMEDevices(logPageEntries, discoveryRequest.Hostnqn, discoveryRequest.Transport, maxIOQueues)
+	ctrls := ConnectAllNVMEDevices(logPageEntries, discoveryRequest.Hostnqn, discoveryRequest.Transport, maxIOQueues, discoveryRequest.HostIface)
 	return ctrls, nil
 }
 
-func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry, hostnqn string, transport string, maxIOQueues int) []*CtrlIdentifier {
+func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry, hostnqn string, transport string, maxIOQueues int, host_iface string) []*CtrlIdentifier {
 	var ctrls []*CtrlIdentifier
 	for _, logPageEntry := range logPageEntries {
 		// skip the non IO subsystems.
@@ -510,6 +514,7 @@ func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry, hostnqn 
 			Transport:   transport,
 			CtrlLossTMO: -1,
 			MaxIOQueues: maxIOQueues,
+			HostIface: host_iface,
 		}
 		ctrlID, err := Connect(request)
 		if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -251,7 +251,7 @@ func (s *service) Start() error {
 						}()
 						continue
 					}
-					nvmeclient.ConnectAllNVMEDevices(nvmeLogPageEntries, request.Hostnqn, request.Transport, s.maxIOQueues)
+					nvmeclient.ConnectAllNVMEDevices(nvmeLogPageEntries, request.Hostnqn, request.Transport, s.maxIOQueues, request.HostIface)
 					refMap := clientconfig.ReferralMap{}
 					for _, referral := range discLogPageEntries {
 						refKey := clientconfig.ReferralKey{

--- a/service/service.go
+++ b/service/service.go
@@ -261,7 +261,7 @@ func (s *service) Start() error {
 							Hostnqn:  conn.Hostnqn}
 						refMap[refKey] = referral
 					}
-					s.cache.HandleReferrals(refMap)
+					s.cache.HandleReferrals(refMap, request)
 				}
 			case <-s.ctx.Done():
 				s.log.Infof("exiting the main func ctx done")


### PR DESCRIPTION
Allow passing a specific host interface such that both:
- the nvme kernel driver can bind to before connecting to the storage
- the discovery-client can bind to before dialing to the discovery-service

This came up by a customer this week, and it seemed fairly simple to add.