### PR TITLE
Revert "service, nvme-client: retry if client fails to connect nvme devices"

### DIFF
--- a/pkg/nvmeclient/nvme_client.go
+++ b/pkg/nvmeclient/nvme_client.go
@@ -491,11 +491,11 @@ func ConnectAll(discoveryRequest *hostapi.DiscoverRequest, maxIOQueues int) ([]*
 	if err != nil {
 		return nil, err
 	}
-	ctrls, err := ConnectAllNVMEDevices(logPageEntries, discoveryRequest.Hostnqn, discoveryRequest.Transport, maxIOQueues)
-	return ctrls, err
+	ctrls := ConnectAllNVMEDevices(logPageEntries, discoveryRequest.Hostnqn, discoveryRequest.Transport, maxIOQueues)
+	return ctrls, nil
 }
 
-func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry, hostnqn string, transport string, maxIOQueues int) ([]*CtrlIdentifier, error) {
+func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry, hostnqn string, transport string, maxIOQueues int) []*CtrlIdentifier {
 	var ctrls []*CtrlIdentifier
 	for _, logPageEntry := range logPageEntries {
 		// skip the non IO subsystems.
@@ -526,14 +526,13 @@ func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry, hostnqn 
 					// we can't deduce that if the DS is down on that node we will fail to connect cause there might be a network partition
 					// on the discovery-service or the DS is down on that node but the IO controller is still accessible.
 					logrus.WithError(perr).Warnf("failed to connect IO controller. In case we have a node down, discovery provides log-page with it's connect info. we will probably fail to connect to it.")
-					return nil, perr
 				}
 			}
 			continue
 		}
 		ctrls = append(ctrls, ctrlID)
 	}
-	return ctrls, nil
+	return ctrls
 }
 
 func Discover(discoveryRequest *hostapi.DiscoverRequest) ([]*hostapi.NvmeDiscPageEntry, error) {

--- a/service/service.go
+++ b/service/service.go
@@ -251,16 +251,7 @@ func (s *service) Start() error {
 						}()
 						continue
 					}
-					_, err = nvmeclient.ConnectAllNVMEDevices(nvmeLogPageEntries, request.Hostnqn, request.Transport, s.maxIOQueues)
-					if err != nil {
-						s.log.WithError(err).Errorf("failed to connect all nvme devices")
-						conn.SetState(false)
-						go func() {
-							triggerReconnectToClusterCh <- clusterMapId
-						}()
-						continue
-					}
-
+					nvmeclient.ConnectAllNVMEDevices(nvmeLogPageEntries, request.Hostnqn, request.Transport, s.maxIOQueues)
 					refMap := clientconfig.ReferralMap{}
 					for _, referral := range discLogPageEntries {
 						refKey := clientconfig.ReferralKey{


### PR DESCRIPTION
Reverts LightBitsLabs/discovery-client#11

Reverted the PR due to failures in test `442_dual_node_vm_installation_test.py` which I'm currently investigating.
The original issue has been fixed (the first workload in the test), but the test fails occasionally on the second workload on `assert len(connected_targets) <= 1, "we can't have more then one connection to the DS"`
let's revert it until we find the root cause