### PR TITLE
nvme_client: set hostid during nvme connection establishment

### DIFF
--- a/pkg/hostapi/host_api.go
+++ b/pkg/hostapi/host_api.go
@@ -35,6 +35,7 @@ type DiscoverRequest struct {
 	Hostaddr  string
 	Kato      time.Duration //keep alive timeout. 0 value signifies request for non persistant connection
 	AENChan   chan AENStruct
+	Hostid    string
 }
 
 // NvmeDiscPageEntry struct represent discovery log page that will be returned from discover method
@@ -81,6 +82,9 @@ func (c *DiscoverRequest) ToOptions() string {
 	}
 	if c.Kato > 0 {
 		sb.WriteString(fmt.Sprintf(",keep_alive_tmo=%d", c.Kato))
+	}
+	if len(c.Hostid) > 0 {
+		sb.WriteString(fmt.Sprintf(",hostid=%s", c.Hostid))
 	}
 	return sb.String()
 }

--- a/pkg/nvmeclient/nvme_client.go
+++ b/pkg/nvmeclient/nvme_client.go
@@ -28,6 +28,7 @@ import (
 	"unsafe"
 
 	"github.com/avast/retry-go"
+	"github.com/google/uuid"
 	"github.com/lightbitslabs/discovery-client/metrics"
 	"github.com/lightbitslabs/discovery-client/pkg/hostapi"
 	"github.com/lightbitslabs/discovery-client/pkg/ioctl"
@@ -105,6 +106,7 @@ type ConnectRequest struct {
 	Subsysnqn   string
 	CtrlLossTMO int
 	MaxIOQueues int
+	Hostid      string
 }
 
 // ToOptions returns a comma delimited key=value string
@@ -132,6 +134,9 @@ func (c *ConnectRequest) ToOptions() string {
 	}
 	if c.MaxIOQueues > 0 {
 		sb.WriteString(fmt.Sprintf(",nr_io_queues=%d", c.MaxIOQueues))
+	}
+	if len(c.Hostid) > 0 {
+		sb.WriteString(fmt.Sprintf(",hostid=%s", c.Hostid))
 	}
 	return sb.String()
 }
@@ -466,6 +471,7 @@ func Connect(request *ConnectRequest) (*CtrlIdentifier, error) {
 		}
 	}
 	request.Traddr = traddr
+	request.Hostid = uuid.NewMD5(uuid.Nil, []byte(request.Hostnqn)).String()
 
 	ctrlID, err := addCtrl(request.ToOptions())
 	if err != nil {
@@ -569,6 +575,7 @@ func Discover(discoveryRequest *hostapi.DiscoverRequest) ([]*hostapi.NvmeDiscPag
 		}
 	}
 	discoveryRequest.Traddr = traddr
+	discoveryRequest.Hostid = uuid.NewMD5(uuid.Nil, []byte(discoveryRequest.Hostnqn)).String()
 
 	ctrlID, err := addCtrl(discoveryRequest.ToOptions())
 	if err != nil {


### PR DESCRIPTION
Starting from kernel v6.5-rc1, there is a new restriction about hostid.
When hostnqn is passed without a specified hostid, the default hostid generated by nvme during initialization is used. The default hostid is already associated with the default hostnqn, So, when attempting to connect with a specified hostnqn, the connection fails due to encountering the same hostid (x) but different hostnqn (y). Therefore, hostid should be provided with hostnqn.

As multiple hostnqns are not currently supported, a constant hostid can be used.

See commit:
https://github.com/torvalds/linux/commit/ae8bd606e09bbdb2607c8249872cc2aeaf2fcc72
    
Issue: LBM1-30942