### PR TITLE
pkg/clientconfig/configgen_test.go: removed unused import cause UT to

### DIFF
--- a/pkg/clientconfig/configgen_test.go
+++ b/pkg/clientconfig/configgen_test.go
@@ -16,7 +16,6 @@ package clientconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"


### PR DESCRIPTION
fail

FAIL    github.com/lightbitslabs/discovery-client/pkg/clientconfig [build failed]