### PR TITLE
service: when we close stopCh we need to nil it to avoid panic

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -22,11 +22,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/lightbitslabs/discovery-client/pkg/clientconfig"
 	"github.com/lightbitslabs/discovery-client/pkg/hostapi"
 	"github.com/lightbitslabs/discovery-client/pkg/nvme"
 	"github.com/lightbitslabs/discovery-client/pkg/nvmeclient"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -182,6 +183,7 @@ func (s *service) Start() error {
 				// first - close any running scheduler for reconnect
 				if stopCh != nil {
 					close(stopCh)
+					stopCh = nil
 				}
 				err := s.reconnectToCluster(clusterMapId)
 				if err != nil {


### PR DESCRIPTION
in case we fail to connect and then we reconnect we would get to a point where we close(stopCh) and on the second iteration we would go into the if stopCh != nil { and try to close it again.

this change will make sure we only close it once and will not go in this if again.

this issue occured in situations where the DSC failed to connect then succeeded and in the third iteration it would panic on closing already closed chan.

issue: LBM1-33584