### PR TITLE
nvmeclient/nvme_client: fix log line to not expect a param

### DIFF
--- a/pkg/nvmeclient/nvme_client.go
+++ b/pkg/nvmeclient/nvme_client.go
@@ -556,7 +556,7 @@ func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry, hostnqn 
 						// discovery service will still report this controller to connect to but we will fail to connect.
 						// we can't deduce that if the DS is down on that node we will fail to connect cause there might be a network partition
 						// on the discovery-service or the DS is down on that node but the IO controller is still accessible.
-						logrus.WithError(perr).Warnf("failed to connect IO controller. This may be a transient error or due to a node being down.",
+						logrus.WithError(perr).Warn("failed to connect IO controller. This may be a transient error or due to a node being down.",
 							"Continuing to attempt connection until the discovery-service stops providing the down node's address..")
 					}
 				}


### PR DESCRIPTION
Issue: No Ticket



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logging for connection failures of IO controllers by simplifying the log message format.
  
- **Chores**
	- Streamlined logging calls for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->