### PR TITLE
discovery-client: allow to override default NVMe host Kato.

### DIFF
--- a/application/app.go
+++ b/application/app.go
@@ -77,7 +77,7 @@ func (app *App) Start() error {
 	}
 	app.cache = clientconfig.NewCache(app.ctx, app.cfg.ClientConfigDir, app.cfg.InternalDir, &app.cfg.AutoDetectEntries)
 	hostAPI := nvmehost.NewHostApi(app.cfg.LogPagePaginationEnabled, app.cfg.NvmeHostIDPath)
-	app.svc = service.NewService(app.ctx, app.cache, hostAPI, app.cfg.ReconnectInterval, app.cfg.MaxIOQueues)
+	app.svc = service.NewService(app.ctx, app.cache, hostAPI, app.cfg.ReconnectInterval, app.cfg.MaxIOQueues, app.cfg.Kato)
 	if err := app.svc.Start(); err != nil {
 		return err
 	}

--- a/cmd/connect-all.go
+++ b/cmd/connect-all.go
@@ -54,6 +54,9 @@ func newConnectAllCmd() *cobra.Command {
 	cmd.Flags().IntP("max-queues", "m", 0, "max-queues")
 	viper.BindPFlag("connect-all.max-queues", cmd.Flags().Lookup("max-queues"))
 
+	cmd.Flags().IntP("kato", "k", 0, "kato")
+	viper.BindPFlag("connect-all.kato", cmd.Flags().Lookup("kato"))
+
 	return cmd
 }
 
@@ -69,7 +72,7 @@ func connectAllCmdFunc(cmd *cobra.Command, args []string) error {
 		Hostnqn:   viper.GetString("connect-all.hostnqn"),
 		Transport: viper.GetString("connect-all.transport"),
 	}
-	ctrls, err := nvmeclient.ConnectAll(entry, viper.GetInt("connect-all.max-queues"))
+	ctrls, err := nvmeclient.ConnectAll(entry, viper.GetInt("connect-all.max-queues"), viper.GetInt("connect-all.kato"))
 	if err != nil {
 		return err
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -79,6 +79,9 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().Int("maxIOQueues", 0, "Overrides the default number of I/O queues create by the driver. Zero value means no override (default driver value is number of cores).")
 	viper.BindPFlag("maxIOQueues", cmd.Flags().Lookup("maxIOQueues"))
 
+	cmd.Flags().Int("kato", 10, "Host keep alive time out")
+	viper.BindPFlag("kato", cmd.Flags().Lookup("kato"))
+
 	// auto detect configuration
 	cmd.Flags().BoolP("autoDetectEntries.enabled", "e", true, "should we detect")
 	viper.BindPFlag("autoDetectEntries.enabled", cmd.Flags().Lookup("autoDetectEntries.enabled"))

--- a/etc/discovery-client/discovery-client.yaml
+++ b/etc/discovery-client/discovery-client.yaml
@@ -4,6 +4,7 @@ internalDir: /etc/discovery-client/internal/
 reconnectInterval: 5s
 logPagePaginationEnabled: false
 maxIOQueues: 0
+kato: 10
 nvmeHostIDPath: /tmp/discovery-client/hostid
 logging:
   filename: "/var/log/discovery-client.log"

--- a/model/app_config.go
+++ b/model/app_config.go
@@ -51,6 +51,7 @@ type AppConfig struct {
 	MaxIOQueues              int               `yaml:"maxIOQueues"`
 	AutoDetectEntries        AutoDetectEntries `yaml:"autoDetectEntries,omitempty"`
 	NvmeHostIDPath           string            `yaml:"nvmeHostIDPath,omitempty"`
+	Kato					 int 			   `yaml:"kato"`
 }
 
 func (cfg *AppConfig) verifyConfigurationIsValid() error {

--- a/service/service.go
+++ b/service/service.go
@@ -56,15 +56,17 @@ type service struct {
 	wg                *sync.WaitGroup
 	reconnectInterval time.Duration
 	maxIOQueues       int
+	kato 			  int
 }
 
-func NewService(ctx context.Context, cache clientconfig.Cache, hostAPI hostapi.HostAPI, reconnectInterval time.Duration, maxIOQueues int) Service {
+func NewService(ctx context.Context, cache clientconfig.Cache, hostAPI hostapi.HostAPI, reconnectInterval time.Duration, maxIOQueues int, kato int) Service {
 	s := &service{
 		log:               logrus.WithFields(logrus.Fields{}),
 		cache:             cache,
 		hostAPI:           hostAPI,
 		reconnectInterval: reconnectInterval,
 		maxIOQueues:       maxIOQueues,
+		kato:              kato,
 	}
 	var wg sync.WaitGroup
 	s.wg = &wg
@@ -253,7 +255,7 @@ func (s *service) Start() error {
 						}()
 						continue
 					}
-					nvmeclient.ConnectAllNVMEDevices(nvmeLogPageEntries, request.Hostnqn, request.Transport, s.maxIOQueues)
+					nvmeclient.ConnectAllNVMEDevices(nvmeLogPageEntries, request.Hostnqn, request.Transport, s.maxIOQueues, s.kato)
 					refMap := clientconfig.ReferralMap{}
 					for _, referral := range discLogPageEntries {
 						refKey := clientconfig.ReferralKey{

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -166,7 +166,7 @@ func TestConnectionsExistAtServiceStart(t *testing.T) {
 	filePath := filepath.Join(userDir, fileName)
 	testutils.CreateFile(t, filePath, fileContent)
 	hostAPIMock := NewHostAPIMock()
-	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0)
+	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0, 10)
 	serviceInterface.Start()
 	correctConnections := func() bool {
 		return correctNumberOfClusterConnectionsInCache(t, serviceInterface, clientconfig.ClientClusterPair{firstSubsysNQN, hostnqn}, numEndpoints)
@@ -218,7 +218,7 @@ func TestConnectionsDualCluster(t *testing.T) {
 				fileIndex += 1
 			}
 			hostAPIMock := NewHostAPIMock()
-			serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0)
+			serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0, 10)
 			serviceInterface.Start()
 			for _, subsysNqn := range tc.clustersAddedAfterServiceStart {
 				fileContent := genFileContent(numEndpointsPerCluster, subsysNqn)
@@ -257,7 +257,7 @@ func TestConnectionsCreatedBeforeAndAfterServeiceStart(t *testing.T) {
 	fileContent := genFileContent(initialNumEndpoints, firstSubsysNQN)
 	filePath := filepath.Join(userDir, fileName)
 	hostAPIMock := NewHostAPIMock()
-	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0)
+	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0, 10)
 	testutils.CreateFile(t, filePath, fileContent)
 	serviceInterface.Start()
 	correctConnections := func() bool {
@@ -321,7 +321,7 @@ func TestConnectionAENNotification(t *testing.T) {
 	fileContent := genFileContent(numEndpoints, firstSubsysNQN)
 	filePath := filepath.Join(userDir, fileName)
 	hostAPIMock := NewHostAPIMock()
-	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0)
+	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0, 10)
 	serviceInterface.Start()
 	testutils.CreateFile(t, filePath, fileContent)
 	correctConnections := func() bool {
@@ -378,7 +378,7 @@ func TestDiscoveryNoLogPageEntries(t *testing.T) {
 	fileContent := genFileContent(numEndpoints, firstSubsysNQN)
 	filePath := filepath.Join(userDir, fileName)
 	hostAPIMock := NewHostAPIMock()
-	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0)
+	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0, 10)
 	serviceInterface.Start()
 	testutils.CreateFile(t, filePath, fileContent)
 	correctConnections := func() bool {
@@ -412,7 +412,7 @@ func TestFailedConnection(t *testing.T) {
 	fileContent := genFileContent(numEndpoints, firstSubsysNQN)
 	filePath := filepath.Join(userDir, fileName)
 	hostAPIMock := NewHostAPIMock()
-	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0)
+	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0, 10)
 	serviceInterface.Start()
 	testutils.CreateFile(t, filePath, fileContent)
 	correctConnections := func() bool {
@@ -442,7 +442,7 @@ func TestConnectionsAddedThroughReferrals(t *testing.T) {
 	fileContent := genFileContent(fileNumEndpoints, firstSubsysNQN)
 	filePath := filepath.Join(userDir, fileName)
 	hostAPIMock := NewHostAPIMock()
-	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0)
+	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0, 10)
 	testutils.CreateFile(t, filePath, fileContent)
 	serviceInterface.Start()
 	correctConnections := func() bool {
@@ -454,7 +454,7 @@ func TestConnectionsAddedThroughReferrals(t *testing.T) {
 	newCtx, newCancel := context.WithCancel(context.Background())
 	defer newCancel()
 	newCache := clientconfig.NewCache(newCtx, userDir, internalDir, nil)
-	newServiceInterface := NewService(newCtx, newCache, hostAPIMock, reconnectInterval, 0)
+	newServiceInterface := NewService(newCtx, newCache, hostAPIMock, reconnectInterval, 0, 10)
 	newServiceInterface.Start()
 	correctConnections = func() bool {
 		return correctNumberOfClusterConnectionsInCache(t, newServiceInterface, clientconfig.ClientClusterPair{firstSubsysNQN, hostnqn}, referralNumEndpoints)
@@ -484,7 +484,7 @@ func TestConnectionsAtStartNotFromJson(t *testing.T) {
 	fileContent := genFileContent(numEndpoints, firstSubsysNQN)
 	filePath := filepath.Join(userDir, fileName)
 	hostAPIMock := NewHostAPIMock()
-	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0)
+	serviceInterface := NewService(ctx, cache, hostAPIMock, reconnectInterval, 0, 10)
 	testutils.CreateFile(t, filePath, fileContent)
 	serviceInterface.Start()
 	correctConnections := func() bool {
@@ -506,7 +506,7 @@ func TestConnectionsAtStartNotFromJson(t *testing.T) {
 	newCtx, newCancel := context.WithCancel(context.Background())
 	defer newCancel()
 	newCache := clientconfig.NewCache(newCtx, userDir, internalDir, nil)
-	newServiceInterface := NewService(newCtx, newCache, hostAPIMock, reconnectInterval, 0)
+	newServiceInterface := NewService(newCtx, newCache, hostAPIMock, reconnectInterval, 0, 10)
 	newServiceInterface.Start()
 	correctConnections = func() bool {
 		return correctNumberOfClusterConnectionsInCache(t, newServiceInterface, clientconfig.ClientClusterPair{firstSubsysNQN, hostnqn}, numEndpoints)


### PR DESCRIPTION
The default Linux NVMe host Kato is 5s in rare case there race in KA and
TBKAS in linux kernel implementation.

As described in commit fixing this issue in Linux, the issue can happen
in following scenario and lead to controller disconnection.

    1. t = 0: run nvme_keep_alive_work, no keep-alive sent
    2. t = ε: I/O completion seen, set comp_seen = true
    3. t = 4: run nvme_keep_alive_work, see comp_seen == true,
              skip sending keep-alive, set comp_seen = false
    4. t = 8: run nvme_keep_alive_work, see comp_seen == false,
              send a keep-alive command.

Allow changing KATO value in discovery client since larger KATO value
should decrease the probablilty of scenario.