### PR TITLE
add set branch step

### DIFF
--- a/.github/workflows/ci_pr.yaml
+++ b/.github/workflows/ci_pr.yaml
@@ -32,6 +32,7 @@ jobs:
       manifest_name: ${{ steps.set_manifest_name.outputs.manifest_name }}
       system_tests_type: ${{ steps.set_system_tests_type.outputs.system_tests_type }}
       max_parallel: ${{ steps.set_max_parallel.outputs.max_parallel }}
+      branch_name: ${{ steps.set_branch_name.outputs.branch_name }}
     steps:
       - id: set_manifest_name
         name: set_manifest_name
@@ -54,6 +55,16 @@ jobs:
         run: |
           echo "max_parallel=${{ env.max_parallel }}" >> $GITHUB_OUTPUT
 
+      - id: set_branch_name
+        name: set_branch_name
+        run: |
+          if [ -z "${GITHUB_HEAD_REF}" ]; then
+            branch_name=${GITHUB_REF_NAME}
+          else
+            branch_name=${GITHUB_HEAD_REF}
+          fi
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+
   trigger_ci_pr:
     needs: populate_env_vars
     name: "Trigger CI PR workflow"
@@ -67,6 +78,6 @@ jobs:
           github_token: ${{ inputs.CI_TOKEN }}
           workflow_file_name: ci_pr.yaml
           ref: main
-          client_payload: '{"manifest_name":"${{ needs.populate_env_vars.outputs.manifest_name }}", "tests_type":"${{ needs.populate_env_vars.outputs.system_tests_type }}", "manifest_branch":"${{ inputs.manifest_branch }}", "github_runner_label":"pr-checks", "run_name":"Discovery Client PR checks"}'
+          client_payload: '{"manifest_name":"${{ needs.populate_env_vars.outputs.manifest_name }}", "tests_type":"${{ needs.populate_env_vars.outputs.system_tests_type }}", "manifest_branch":"${{ inputs.manifest_branch }}", "github_runner_label":"pr-checks", "run_name":"Discovery Client PR checks", "branch_name":"${{ needs.populate_env_vars.outputs.branch_name }}"}'
           trigger_workflow: true
           wait_workflow: true

--- a/.github/workflows/ci_pr.yaml
+++ b/.github/workflows/ci_pr.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   populate_env_vars:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, public-pr-checks ]
     name: populate_env_vars
     outputs:
       manifest_name: ${{ steps.set_manifest_name.outputs.manifest_name }}
@@ -68,7 +68,7 @@ jobs:
   trigger_ci_pr:
     needs: populate_env_vars
     name: "Trigger CI PR workflow"
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, public-pr-checks ]
     steps:
       - name:  Trigger CI PR workflow
         uses: convictional/trigger-workflow-and-wait@v1.6.5


### PR DESCRIPTION
This step is necessary in order to be able to checkout the correct branch from discovery-client when running in the internal CI runners.
Also, moved from managed runner to run on self hosted runner.

Issue: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new input parameter for the CI workflow to specify the branch name.
	- Added an output variable to enhance the workflow's capability in identifying the branch being used.

These updates improve the flexibility and clarity of the CI process, ensuring better handling of branch-specific operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->