### PR TITLE
New PR template + Calling PR dependencies workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+**PR description**  
+<!--
+Provide a clear and concise description of what this PR does and why it is needed.
+Explain the problem it solves or the feature it introduces.
+-->
+
+**How was the PR tested?**  
+<!--
+Detail the testing process for this PR.
+- Did you run PR checks? Were they successful?
+- Did you perform partial or full sanity tests?
+- Were nightly or weekly tests executed? Any performance tests?
+- Did you add new tests specifically for this PR?
+Clearly state what was tested and the results.
+-->
+
+**PR dependencies**  
+<!--
+List any dependent PRs in any repositories that must be merged before this one.
+Include valid links to those PRs between the tags below without modifying the tags.
+-->
+<!-- PR_DEPS_START -->
+<!-- PR_DEPS_END -->
+
+**Jira Ticket**  
+Issue: LBM1-XXXX

--- a/.github/workflows/ci_pr.yaml
+++ b/.github/workflows/ci_pr.yaml
@@ -26,6 +26,15 @@ env:
   manifest_branch: "master"
 
 jobs:
+  run_pr_dependencies_check:
+    if: github.event_name == 'pull_request'
+    name: "Run PR dependencies check"
+    uses: LightBitsLabs/lbcitests/.github/workflows/pr-dependencies-check.yaml@main
+    secrets: inherit
+    with:
+      pr_number: ${{ github.event.number }}
+      repo_name: ${{ github.event.repository.name }}
+
   populate_env_vars:
     runs-on: [ self-hosted, public-pr-checks ]
     name: populate_env_vars


### PR DESCRIPTION
This pull request introduces a new section in the pull request template for listing dependencies and adds a new job to the CI workflow to check for pull request dependencies.

Changes to pull request template and CI workflow:

* [`.github/pull_request_template.md`](diffhunk://#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bR1-R4): Added a new section `PR Dependencies` to the pull request template to allow users to list dependencies.
* [`.github/workflows/ci_pr.yaml`](diffhunk://#diff-1fa67072b1891c06b7cd9bf0b8d46d0acf40d3fce70e9aed669205c037a19e48R29-R37): Added a new job `run_pr_dependencies_check` to the CI workflow that triggers on pull requests and uses the `pr-dependencies-check.yaml` workflow to verify dependencies.

Issue: LBM1-36923