### PR TITLE
nvme: fix identify against wrong port

### DIFF
--- a/pkg/nvme/nvmehost/tcp_queue.go
+++ b/pkg/nvme/nvmehost/tcp_queue.go
@@ -404,9 +404,21 @@ func (queue *tcpQueue) sendIdentifyRequest(ctx context.Context) error {
 		return err
 	}
 
+	// did we get back a valid response?
+	if completedRequest == nil {
+		return fmt.Errorf("queue %d [%v]: got nil identify response",
+			queue.id, queue.tcpConn.RemoteAddr())
+	}
+
+	data := completedRequest.GetData()
+	if data == nil {
+		return fmt.Errorf("queue %d [%v]: got identify response with nil data",
+			queue.id, queue.tcpConn.RemoteAddr())
+	}
+
 	// copy sgl to buffer
 	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, nvme.NewScatterListReader(completedRequest.GetData())); err != nil {
+	if _, err := io.Copy(&buf, nvme.NewScatterListReader(data)); err != nil {
 		return err
 	}
 	pduReader := bytes.NewReader(buf.Bytes())


### PR DESCRIPTION
The identify implementation was a little naive in assuming that it will get back a valid response. When running `nvme discover` against a random port, we would crash here with a nil pointer exception. This fix is probably needed in plenty of other places, but let's fix this one first.

Issue: LBM1-36790

How was it tested? Manually and PR check will run.
```
root@rack08-server71-vm03 [client]:~# ./discovery-client discover -a 10.18.82.7 -s 4420 -q shai_client
Error: queue 1 [10.18.82.7:4420]: got identify response with nil data
root@rack08-server71-vm03 [client]:~# echo $?
255
```
