### PR TITLE
configuration: comment out default cores: [0] - backport to v3.15.x

### DIFF
--- a/etc/discovery-client/discovery-client.yaml
+++ b/etc/discovery-client/discovery-client.yaml
@@ -1,4 +1,4 @@
-cores: [0]
+# cores: [0]
 clientConfigDir: /etc/discovery-client/discovery.d/
 internalDir: /etc/discovery-client/internal/
 reconnectInterval: 5s


### PR DESCRIPTION
## Backport to v3.15.x of PR #43 
## Testing comments

- Passed CI sanity with discovery-client tag, verified that the AppConfig now contains Cores:[]int(nil), meaning that the taskset utility is not even executed - included test 1923 and 239

## Future considerations

- It is expected that (1) clients will not normally need to reconfigure the yaml
- The Cores: section of the yaml remains supported now, but it should be removed in the future (including the code that parses it and invokes taskset retroactively)
- If needed for some reason, users can invoke discovery-client using taskset from the beginning

## Description

Comment out the default specification of CPU affinity to core 0 in discovery-client.yaml, to allow more flexible invocation even in systems where for some reason core 0 is offline or otherwise unavailable.

It is still possible to uncomment the line and specify a list of ID's for CPU affinity, but if the line is missing or the list is empty, no taskset command is invoked.

Issue: LBM1-37901