### PR TITLE
build: add Linux arch

### DIFF
--- a/Makefile.lb
+++ b/Makefile.lb
@@ -37,5 +37,6 @@ push-image-ubi9:
 discovery-rpms:
 	$(BUILD_FLAGS) $(MAKE) -f Makefile discovery-rpms
 
-discovery-packages:
-	$(BUILD_FLAGS) $(MAKE) -f Makefile discovery-packages
+discovery-packages-%:
+	@echo "Building discovery packages for $*"
+	$(BUILD_FLAGS) $(MAKE) -f Makefile discovery-packages-$*

--- a/lb.yaml
+++ b/lb.yaml
@@ -15,11 +15,28 @@ discovery-client:
     - file://service
     - file://vendor
 
-  discovery-client-packages:
+  discovery-client-packages-el8:
     build:
-    - make discovery-packages -f Makefile.lb
+    - make discovery-packages-el8 -f Makefile.lb
     install:
-    - make install-discovery-client-packages
+    - make install-discovery-client-packages-el8
+    deps:
+    - common:milestone
+    - file://Makefile
+    - file://Makefile.lb
+    - file://pkg
+    - file://model
+    - file://vendor
+    - file://application
+    - file://main.go
+    - file://go.mod
+    - file://discovery-client.spec
+
+  discovery-client-packages-el9:
+    build:
+    - make discovery-packages-el9 -f Makefile.lb
+    install:
+    - make install-discovery-client-packages-el9
     deps:
     - milestone:milestone
     - file://Makefile


### PR DESCRIPTION
This pull request modifies the `Makefile` to address issues with version formatting and RPM build definitions. The most important change ensures that tilde (`~`) characters are removed from version strings and updates the RPM build process to exclude the tilde in the `dist` definition.

Makefile updates:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L71-R75): Adjusted the `VERSION` assignment in the `discovery-rpms` target to remove tilde (`~`) characters using the `tr` command. This ensures cleaner version strings.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L71-R75): Updated the `rpmbuild` command in the `discovery-rpms` target to exclude the tilde (`~`) in the `dist` definition, simplifying the RPM naming convention.


Issue: LBM1-38037


https://github.com/LightBitsLabs/discovery-service/pull/158
https://github.com/LightBitsLabs/common/pull/4527
https://github.com/LightBitsLabs/management/pull/6794
https://github.com/LightBitsLabs/duroslight/pull/1896
https://github.com/LightBitsLabs/kernelight/pull/4324
https://github.com/LightBitsLabs/light-app/pull/1078