### PR TITLE
config: add config option for auxiliary subsystems

### DIFF
--- a/application/app.go
+++ b/application/app.go
@@ -85,7 +85,7 @@ func (app *App) Start() error {
 	}
 	app.cache = clientconfig.NewCache(app.ctx, app.cfg.ClientConfigDir, app.cfg.InternalDir, &app.cfg.AutoDetectEntries)
 	hostAPI := nvmehost.NewHostApi(app.cfg.LogPagePaginationEnabled, app.cfg.NvmeHostIDPath)
-	app.svc = service.NewService(app.ctx, app.cache, hostAPI, app.cfg.ReconnectInterval, app.cfg.MaxIOQueues, app.cfg.Kato)
+	app.svc = service.NewService(app.ctx, app.cache, hostAPI, app.cfg.ReconnectInterval, app.cfg.MaxIOQueues, app.cfg.Kato, app.cfg.AuxSuffix)
 	if err := app.svc.Start(); err != nil {
 		return err
 	}

--- a/model/app_config.go
+++ b/model/app_config.go
@@ -54,6 +54,7 @@ type AppConfig struct {
 	AutoDetectEntries        AutoDetectEntries `yaml:"autoDetectEntries,omitempty"`
 	NvmeHostIDPath           string            `yaml:"nvmeHostIDPath,omitempty"`
 	Kato                     int               `yaml:"kato"`
+	AuxSuffix                string            `yaml:"auxSuffix,omitempty"`
 }
 
 func (cfg *AppConfig) verifyConfigurationIsValid() error {

--- a/pkg/nvmeclient/nvme_client.go
+++ b/pkg/nvmeclient/nvme_client.go
@@ -41,6 +41,13 @@ import (
 //#include <../nvme/linux/nvme.h>
 import "C"
 
+// AuxSuffix is the default suffix to append to subsystem NQN
+var AuxSuffix = ""
+
+func SetAuxSuffix(suffix string) {
+	AuxSuffix = suffix
+}
+
 type NvmeClientError struct {
 	Msg    string
 	Status int
@@ -489,6 +496,10 @@ func Connect(request *ConnectRequest) (*CtrlIdentifier, error) {
 				Err:    err,
 			}
 		}
+	}
+
+	if AuxSuffix != "" {
+		request.Subsysnqn = fmt.Sprintf("%s.%s", request.Subsysnqn, AuxSuffix)
 	}
 
 	ctrlID, err := addCtrl(request.ToOptions())

--- a/service/service.go
+++ b/service/service.go
@@ -59,7 +59,7 @@ type service struct {
 	kato              int
 }
 
-func NewService(ctx context.Context, cache clientconfig.Cache, hostAPI hostapi.HostAPI, reconnectInterval time.Duration, maxIOQueues int, kato int) Service {
+func NewService(ctx context.Context, cache clientconfig.Cache, hostAPI hostapi.HostAPI, reconnectInterval time.Duration, maxIOQueues int, kato int, aux string) Service {
 	s := &service{
 		log:               logrus.WithFields(logrus.Fields{}),
 		cache:             cache,
@@ -67,6 +67,12 @@ func NewService(ctx context.Context, cache clientconfig.Cache, hostAPI hostapi.H
 		reconnectInterval: reconnectInterval,
 		maxIOQueues:       maxIOQueues,
 		kato:              kato,
+	}
+
+	// Set the auxiliary suffix for NVMe connections
+	if aux != "" {
+		nvmeclient.SetAuxSuffix(aux)
+		logrus.Infof("Starting service using auxiliary subsystem with suffix %s", aux)
 	}
 	var wg sync.WaitGroup
 	s.wg = &wg


### PR DESCRIPTION
This pull request introduces support for an auxiliary suffix (`AuxSuffix`) in NVMe subsystem NQN configurations, allowing more flexibility in naming conventions. The changes span multiple files, adding configuration options, modifying service initialization, and updating NVMe client behavior.

### Configuration Updates:
* [`model/app_config.go`](diffhunk://#diff-28b284e5fd4ec0ebcdea3321882e403c670948cea363ba2dc0c059c8ae46a358R57): Added a new field `AuxSuffix` to the `AppConfig` struct to allow specifying a suffix for NVMe subsystem NQN.

### Service Initialization:
* [`application/app.go`](diffhunk://#diff-8cfaf5257b416daf0de81b245fc333847ec145dda9e60ae7b56d523fb7d7795fL88-R88): Updated the `NewService` call to include the `AuxSuffix` parameter during service initialization.
* [`service/service.go`](diffhunk://#diff-85ee04e67bda04e6159b92426c87fe161c58d4b5550ef2b0fa7a97214309c125L62-R62): Modified the `NewService` function to accept the `AuxSuffix` parameter and set it in the NVMe client. Added logging to indicate the auxiliary suffix being used.
*
### NVMe Client Enhancements:
* [`pkg/nvmeclient/nvme_client.go`](diffhunk://#diff-79b63a572f7e07ec5eaf66cd9bc83df1f0fe5036a319135ab01e9db919ceb8fdR44-R50): Introduced a global variable `AuxSuffix` and a setter function `SetAuxSuffix`. Updated the `Connect` function to append the suffix to the subsystem NQN if `AuxSuffix` is set. 

Issue: LBM1-38341