### PR TITLE
lb.yaml: Change milestone reference

### DIFF
--- a/lb.yaml
+++ b/lb.yaml
@@ -21,7 +21,7 @@ discovery-client:
     install:
     - make install-discovery-client-packages
     deps:
-    - common:milestone
+    - milestone:milestone
     - file://Makefile
     - file://Makefile.lb
     - file://pkg


### PR DESCRIPTION
**PR description**  
_Change milestone reference_
The milestone file is moving to a new repo called milestone in order to stop garbage in the Common repo by the Sanity workflow.
In addition, this PR also changes the reference accordingly in all relevant build files.


**How was the PR tested?**  
The PR was tested via partial Sanity that ran a fully built process, followed by 3 tests:
https://github.com/LightBitsLabs/lbcitests/actions/runs/16046724290

During the run, I checked that no common:milestone dependencies were built, but only milestone:milestone.


**PR dependencies**  
This PR is part of several PRs that should be merged together. Please see the list below.
<!-- PR_DEPS_START -->
<!-- PR_DEPS_END -->

**Jira Ticket**  
Issue: LBM1-37249