### PR TITLE
Gila/dhchap

### DIFF
--- a/application/app.go
+++ b/application/app.go
@@ -85,7 +85,8 @@ func (app *App) Start() error {
 	}
 	app.cache = clientconfig.NewCache(app.ctx, app.cfg.ClientConfigDir, app.cfg.InternalDir, &app.cfg.AutoDetectEntries)
 	hostAPI := nvmehost.NewHostApi(app.cfg.LogPagePaginationEnabled, app.cfg.NvmeHostIDPath)
-	app.svc = service.NewService(app.ctx, app.cache, hostAPI, app.cfg.ReconnectInterval, app.cfg.MaxIOQueues, app.cfg.Kato, app.cfg.AuxSuffix)
+	app.svc = service.NewServiceExtended(app.ctx, app.cache, hostAPI, *app.cfg)
+	//app.svc = service.NewService(app.ctx, app.cache, hostAPI, app.cfg.ReconnectInterval, app.cfg.MaxIOQueues, app.cfg.Kato, app.cfg.AuxSuffix)
 	if err := app.svc.Start(); err != nil {
 		return err
 	}

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -59,6 +59,11 @@ specified by the --nqn option.`,
 	cmd.Flags().IntP("ctrl-loss-tmo", "", -1, "controller loss timeout period (in seconds). Timeout is disabled by default (-1)")
 	viper.BindPFlag("connect.ctrl-loss-tmo", cmd.Flags().Lookup("ctrl-loss-tmo"))
 
+	cmd.Flags().StringP("dhchap-secret", "S", "", "user-defined dhchap key")
+	viper.BindPFlag("connect.dhchap-secret", cmd.Flags().Lookup("dhchap-secret"))
+
+	cmd.Flags().StringP("dhchap-ctrl-secret", "C", "", "user-defined dhchap controller key")
+	viper.BindPFlag("connect.dhchap-ctrl-secret", cmd.Flags().Lookup("dhchap-ctrl-secret"))
 	return cmd
 }
 
@@ -70,14 +75,20 @@ func connectCmdFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("nqn(-n) must be set")
 	}
 
+	if viper.IsSet("connect.dhchap-ctrl-secret") && !viper.IsSet("connect.dhchap-secret") {
+		return fmt.Errorf("dhchap-secret must be specified when dhchap-ctrl-secret is set")
+	}
+
 	request := &nvmeclient.ConnectRequest{
-		Traddr:      viper.GetString("connect.traddr"),
-		Trsvcid:     viper.GetInt("connect.trsvcid"),
-		Subsysnqn:   viper.GetString("connect.nqn"),
-		Hostnqn:     viper.GetString("connect.hostnqn"),
-		Hostid:      viper.GetString("connect.hostid"),
-		Transport:   viper.GetString("connect.transport"),
-		CtrlLossTMO: viper.GetInt("connect.ctrl-loss-tmo"),
+		Traddr:                 viper.GetString("connect.traddr"),
+		Trsvcid:                viper.GetInt("connect.trsvcid"),
+		Subsysnqn:              viper.GetString("connect.nqn"),
+		Hostnqn:                viper.GetString("connect.hostnqn"),
+		Hostid:                 viper.GetString("connect.hostid"),
+		Transport:              viper.GetString("connect.transport"),
+		CtrlLossTMO:            viper.GetInt("connect.ctrl-loss-tmo"),
+		DhChapSecret:           viper.GetString("connect.dhchap-secret"),
+		DhChapControllerSecret: viper.GetString("connect.dhchap-ctrl-secret"),
 	}
 	ctrlID, err := nvmeclient.Connect(request)
 	if err != nil {

--- a/model/app_config.go
+++ b/model/app_config.go
@@ -55,6 +55,8 @@ type AppConfig struct {
 	NvmeHostIDPath           string            `yaml:"nvmeHostIDPath,omitempty"`
 	Kato                     int               `yaml:"kato"`
 	AuxSuffix                string            `yaml:"auxSuffix,omitempty"`
+	DhChapSecret             string            `yaml:"dhChapSecret,omitempty"`
+	DhChapCtrlSecret         string            `yaml:"dhChapCtrlSecret,omitempty"`
 }
 
 func (cfg *AppConfig) verifyConfigurationIsValid() error {
@@ -64,6 +66,11 @@ func (cfg *AppConfig) verifyConfigurationIsValid() error {
 	if cfg.ReconnectInterval == 0 {
 		cfg.ReconnectInterval = 5 * time.Second
 	}
+
+	if cfg.DhChapSecret != "" && cfg.DhChapCtrlSecret == "" {
+		return fmt.Errorf("dhchapctrlsecret is mandatory when using dhchapsecret")
+	}
+
 	return cfg.Logging.IsValid()
 }
 

--- a/pkg/nvmeclient/nvme_client.go
+++ b/pkg/nvmeclient/nvme_client.go
@@ -105,17 +105,17 @@ type CtrlIdentifier struct {
 }
 
 type ConnectRequest struct {
-	Transport   string
-	Traddr      string
-	Trsvcid     int
-	Hostnqn     string
-	Hostaddr    string
-	Subsysnqn   string
-	CtrlLossTMO int
-	MaxIOQueues int
-	Hostid      string
-	Kato        int
-	DhChapSecret string
+	Transport              string
+	Traddr                 string
+	Trsvcid                int
+	Hostnqn                string
+	Hostaddr               string
+	Subsysnqn              string
+	CtrlLossTMO            int
+	MaxIOQueues            int
+	Hostid                 string
+	Kato                   int
+	DhChapSecret           string
 	DhChapControllerSecret string
 }
 
@@ -157,7 +157,7 @@ func (c *ConnectRequest) ToOptions() string {
 
 	}
 	// must have DhChapSecret when using DhChapControllerSecret
-	if c.DhChapSecret != ""  && c.DhChapControllerSecret != "" {
+	if c.DhChapSecret != "" && c.DhChapControllerSecret != "" {
 		sb.WriteString(fmt.Sprintf(",dhchap_ctrl_secret=%s", c.DhChapControllerSecret))
 
 	}
@@ -544,7 +544,7 @@ func ConnectAll(discoveryRequest *hostapi.DiscoverRequest,
 	}
 	ctrls := ConnectAllNVMEDevices(logPageEntries, discoveryRequest.Hostnqn,
 		discoveryRequest.Hostid,
-		discoveryRequest.Transport, maxIOQueues, kato, ctrlLossTMO)
+		discoveryRequest.Transport, maxIOQueues, kato, ctrlLossTMO, nil)
 	return ctrls, nil
 }
 
@@ -572,6 +572,7 @@ func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry,
 	transport string,
 	maxIOQueues int, kato int,
 	ctrlLossTMO *int,
+	cfg *model.AppConfig,
 ) []*CtrlIdentifier {
 	var ctrls []*CtrlIdentifier
 	for _, logPageEntry := range logPageEntries {
@@ -594,6 +595,12 @@ func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry,
 			MaxIOQueues: maxIOQueues,
 			Kato:        kato,
 		}
+
+		if cfg != nil {
+			request.DhChapSecret = cfg.DhChapSecret
+			request.DhChapControllerSecret = cfg.DhChapCtrlSecret
+		}
+
 		ctrlID, err := Connect(request)
 		if err != nil {
 			// we might get 2 problems here, either we already connected, and we don't care about this error

--- a/pkg/nvmeclient/nvme_client.go
+++ b/pkg/nvmeclient/nvme_client.go
@@ -115,6 +115,8 @@ type ConnectRequest struct {
 	MaxIOQueues int
 	Hostid      string
 	Kato        int
+	DhChapSecret string
+	DhChapControllerSecret string
 }
 
 // ToOptions returns a comma delimited key=value string
@@ -148,6 +150,16 @@ func (c *ConnectRequest) ToOptions() string {
 	}
 	if c.Kato > 0 {
 		sb.WriteString(fmt.Sprintf(",keep_alive_tmo=%d", c.Kato))
+	}
+
+	if c.DhChapSecret != "" {
+		sb.WriteString(fmt.Sprintf(",dhchap_secret=%s", c.DhChapSecret))
+
+	}
+	// must have DhChapSecret when using DhChapControllerSecret
+	if c.DhChapSecret != ""  && c.DhChapControllerSecret != "" {
+		sb.WriteString(fmt.Sprintf(",dhchap_ctrl_secret=%s", c.DhChapControllerSecret))
+
 	}
 	return sb.String()
 }


### PR DESCRIPTION
This pull request introduces support for DH-CHAP authentication secrets in the NVMe connection workflow, adds configuration validation for these secrets, and refactors service initialization to use a more extensible configuration pattern. The changes ensure that DH-CHAP secrets can be provided via CLI flags and configuration, are validated for consistency, and are correctly propagated throughout the connection logic.

**DH-CHAP Authentication Support:**

* Added CLI flags `--dhchap-secret` and `--dhchap-ctrl-secret` to allow users to specify DH-CHAP authentication secrets for NVMe connections. These flags are bound to configuration via `viper`.
* Updated `ConnectRequest` and its option string builder to include the new DH-CHAP secrets, ensuring they are passed to the NVMe subsystem when provided. [[1]](diffhunk://#diff-79b63a572f7e07ec5eaf66cd9bc83df1f0fe5036a319135ab01e9db919ceb8fdR118-R119) [[2]](diffhunk://#diff-79b63a572f7e07ec5eaf66cd9bc83df1f0fe5036a319135ab01e9db919ceb8fdR154-R163)
* Modified connection logic to require `dhchap-secret` when `dhchap-ctrl-secret` is specified, enforcing proper usage.

**Configuration Model and Validation:**

* Extended `AppConfig` to include `DhChapSecret` and `DhChapCtrlSecret` fields, and added validation to ensure both secrets are specified together when needed. [[1]](diffhunk://#diff-28b284e5fd4ec0ebcdea3321882e403c670948cea363ba2dc0c059c8ae46a358R58-R59) [[2]](diffhunk://#diff-28b284e5fd4ec0ebcdea3321882e403c670948cea363ba2dc0c059c8ae46a358R69-R73)

**Service Initialization Refactor:**

* Refactored service creation to use `NewServiceExtended`, passing the full `AppConfig` struct for greater extensibility and future-proofing. [[1]](diffhunk://#diff-8cfaf5257b416daf0de81b245fc333847ec145dda9e60ae7b56d523fb7d7795fL88-R89) [[2]](diffhunk://#diff-85ee04e67bda04e6159b92426c87fe161c58d4b5550ef2b0fa7a97214309c125R61-R85)
* Updated internal service connection logic to propagate DH-CHAP secrets from configuration to NVMe device connections. [[1]](diffhunk://#diff-85ee04e67bda04e6159b92426c87fe161c58d4b5550ef2b0fa7a97214309c125L268-R294) [[2]](diffhunk://#diff-79b63a572f7e07ec5eaf66cd9bc83df1f0fe5036a319135ab01e9db919ceb8fdR575) [[3]](diffhunk://#diff-79b63a572f7e07ec5eaf66cd9bc83df1f0fe5036a319135ab01e9db919ceb8fdR598-R603)

These changes collectively improve authentication flexibility, configuration safety, and code maintainability for NVMe connection management.