### PR TITLE
nvme/cfg: eliminate stale ctrls by using a finite ctrl_loss_tmo

### DIFF
--- a/model/app_config.go
+++ b/model/app_config.go
@@ -57,6 +57,7 @@ type AppConfig struct {
 	AuxSuffix                string            `yaml:"auxSuffix,omitempty"`
 	DhChapSecret             string            `yaml:"dhChapSecret,omitempty"`
 	DhChapCtrlSecret         string            `yaml:"dhChapCtrlSecret,omitempty"`
+	CtrlLossTMO              int               `yaml:"ctrlLossTMO"`
 }
 
 func (cfg *AppConfig) verifyConfigurationIsValid() error {
@@ -71,6 +72,9 @@ func (cfg *AppConfig) verifyConfigurationIsValid() error {
 		return fmt.Errorf("dhchapsecret is mandatory when using dhchapctrlsecret")
 	}
 
+	if cfg.CtrlLossTMO == 0 || cfg.CtrlLossTMO < -1 {
+		cfg.CtrlLossTMO = 600
+	}
 	return cfg.Logging.IsValid()
 }
 

--- a/pkg/nvmeclient/nvme_client.go
+++ b/pkg/nvmeclient/nvme_client.go
@@ -620,7 +620,7 @@ func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry,
 		if logPageEntry.SubType != nvme.NVME_NQN_NVME {
 			continue
 		}
-		ctrlLossTMOValue := -1
+		ctrlLossTMOValue := cfg.CtrlLossTMO
 		if ctrlLossTMO != nil {
 			ctrlLossTMOValue = *ctrlLossTMO
 		}


### PR DESCRIPTION
Until now we had a ctrl_loss_tmo set to -1 by default.

**This is likely a wrong lesson learnt from setups and tests with "manual" nvme connect's, where indeed ctrl_loss_tmo set lower than the maximal node downtime results in missing node connection later when the node comes back.**

This means a controller, once connected, is never removed, e.g. if a server is taken down/deleted,
the corresponding controllers will remain reconnecting forever on all client machines, until manually disconnected.

Solution:
- Add ctrlLossTMO to discovery-client.yaml (int, seconds, default is 600)
- Thus, any controller that cannot reconnect within this time will be automatically removed by nvme subsystem. NOTE: this won't take effect for existing controllers connected by an older discovery-client. The cluster discovery service notifies relevant discovery-clients when a node becomes active, so if a node is down and the corresponding controller is removed after 600s,
discovery-client will reconnect it once the node becomes active.

Consequences to expect:
1) If an server node is down and the corresponding controller is removed after 600s, discovery-client will reconnect it once the node becomes active: the cluster discovery service notifies relevant discovery-clients when a node becomes active.
2) If a client looses network connectivity to the servers, and the IO controllers are removed after 600s, But, discovery-client will also get disconnected and will keep trying to reconnect to the discovery endpoints. When network connectivity is restored, DC will succeed, fetch a log page,  and connect all the required IO controllers.
3) If a server is removed from the cluster, the discovery client configuration will still have this endpoint listed: discovery-client attempts to connect to it will fail to connect to a server that is gone or down, thus another endpoint will be picked.
4) If a client looses connection to all replicas of a volume (due to LB nodes being down or a network issue like (2), after 600s all IO controllers are removed, and the IO to the volume will fail ("no path available - failing IO). Before this change the IO would hang forever without failing (possible path present). The ctrlLossTMO in the configuration file can be used to mitigate this if needed.

** How this PR was tested **
- Manually verified the discovery connects a node after it becomes active again
- Tests: 529, 279

Issue: LBM1-37762