### PR TITLE
Backport: Makefile add another build for deb package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,18 +142,20 @@ discovery-rpms-%: build/dist build/discovery-client
 	$(Q) rm -rf ${RPMOUT_DIR}
 	$(Q) rpmbuild -bb --clean --define="version ${VERSION}" --define="_builddir `pwd`" --define="dist $(DISCOVERY_CLIENT_RELEASE).$*" --define "_rpmdir $(RPMOUT_DIR)" discovery-client.spec
 
-discovery-client-debs-%:
-	(cd build/dist && sudo alien --to-deb -v -k ${RPMOUT_DIR}/x86_64/discovery-client*.rpm && sudo chown ${USER}:${USER} ${WORKSPACE_TOP}/discovery-client/build/dist/*.deb)
+discovery-client-debs: VERSION = $(or $(LIGHTOS_VERSION),$(DEFAULT_REL))
+discovery-client-debs:
+	$(Q) rpmbuild -bb --clean --define="version ${VERSION}" --define="_builddir `pwd`" --define="dist $(DISCOVERY_CLIENT_RELEASE)" --define "_rpmdir $(RPMOUT_DIR)" discovery-client.spec
+	(cd build/dist && sudo alien --to-deb -v -k ${RPMOUT_DIR}/x86_64/discovery-client-${VERSION}-${DISCOVERY_CLIENT_RELEASE}.x86_64.rpm && sudo chown ${USER}:${USER} ${WORKSPACE_TOP}/discovery-client/build/dist/*.deb)
 
-discovery-packages-el8: discovery-rpms-el8 discovery-client-debs-el8
+discovery-packages-el8: discovery-rpms-el8 discovery-client-debs
 
-discovery-packages-el9: discovery-rpms-el9 discovery-client-debs-el9
+discovery-packages-el9: discovery-rpms-el9 discovery-client-debs
 
 install-discovery-client-packages-%: COMPONENT_PATH = $(shell component-tool localpath --repo=discovery-client --type=$(BUILD_TYPE) discovery-client-packages-$*)
 install-discovery-client-packages-%:
 	$(Q)mkdir -p $(COMPONENT_PATH)/
 	$(Q)rm -rf $(COMPONENT_PATH)/*.rpm $(COMPONENT_PATH)/*.deb
-	$(Q)cp ${RPMOUT_DIR}/x86_64/discovery-client*.rpm $(COMPONENT_PATH)/
+	$(Q)cp ${RPMOUT_DIR}/x86_64/discovery-client*el*.rpm $(COMPONENT_PATH)/
 	$(Q)cp build/dist/discovery-client*.deb $(COMPONENT_PATH)/
 	echo "Installed discovery-client RPMs and DEBs"
 

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ install-discovery-client:
 	$(Q)cp -Rf ./etc/ $(COMPONENT_PATH)/
 	echo "Installed discovery-client component"
 
-.PHONY: discovery-rpms-% discovery-client-debs-%\
+.PHONY: discovery-rpms-% discovery-client-debs \
 	discovery-packages-el8 \
 	discovery-packages-el9 \
 	install-discovery-client-packages-% \


### PR DESCRIPTION
## Summary
- Backport of PR #56 from main to `Lightbits_3_18_branch`
- Adds another build target for deb packages to fix package naming when using alien to convert from rpm to deb

Issue: LBM1-42364

## Original PR
https://github.com/LightBitsLabs/discovery-client/pull/56

## Test plan
- [ ] Verify deb package build works correctly with the new target