### PR TITLE
nvme_client: fix nil pointer dereference in connect-all

### DIFF
--- a/pkg/nvmeclient/nvme_client.go
+++ b/pkg/nvmeclient/nvme_client.go
@@ -620,10 +620,14 @@ func ConnectAllNVMEDevices(logPageEntries []*hostapi.NvmeDiscPageEntry,
 		if logPageEntry.SubType != nvme.NVME_NQN_NVME {
 			continue
 		}
-		ctrlLossTMOValue := cfg.CtrlLossTMO
+
+		ctrlLossTMOValue := -1
 		if ctrlLossTMO != nil {
 			ctrlLossTMOValue = *ctrlLossTMO
+		} else if cfg != nil {
+			ctrlLossTMOValue = cfg.CtrlLossTMO
 		}
+
 		request := &ConnectRequest{
 			Traddr:      logPageEntry.Traddr,
 			Trsvcid:     int(logPageEntry.TrsvcID),


### PR DESCRIPTION
The commit below introduced an issue with command-line operations like connect-all:
unlike IO ctrl connects initiated by discovery-client.service command line connects do not have cfg set
causing a panic (NPD) on access to a nil cfg.

Fix:
- lossTMO default is -1
- the ctrlLossTMO argument, if provided, overrides
- otherwise the cfg.CtrlLossTMO, if cfg provided, overrides

Fixes: 3b7d7def9e6fdd2bd3456f6f47deec64f712d507