### PR TITLE
metrics: add discovery_netdev_mtu_bytes gauge

### DIFF
--- a/application/app.go
+++ b/application/app.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 
+	"github.com/lightbitslabs/discovery-client/metrics"
 	"github.com/lightbitslabs/discovery-client/model"
 	"github.com/lightbitslabs/discovery-client/pkg/clientconfig"
 	"github.com/lightbitslabs/discovery-client/pkg/nvme/nvmehost"
@@ -61,6 +62,7 @@ func (app *App) Start() error {
 	go func() {
 		if len(app.cfg.Debug.Endpoint) > 0 {
 			http.Handle("/metrics", promhttp.Handler())
+			go metrics.RunNetdevMTUCollector(app.ctx)
 			app.log.Infof("%v", http.ListenAndServe(app.cfg.Debug.Endpoint, nil))
 		}
 	}()

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/client_golang v1.13.0
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/procfs v0.8.0
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.0
@@ -34,13 +36,12 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
-	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
 	golang.org/x/text v0.3.8 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -28,6 +28,8 @@ type DiscoveryClientMetrics struct {
 	FileEntries *prometheus.GaugeVec
 	// DiscoveryLogPageCount - count how much log pages we got for each hostnqn
 	DiscoveryLogPageCount *prometheus.GaugeVec
+	// NetdevMTUBytes - MTU of each local network device
+	NetdevMTUBytes *prometheus.GaugeVec
 }
 
 var Metrics DiscoveryClientMetrics
@@ -61,10 +63,18 @@ func init() {
 		},
 		[]string{},
 	)
+	Metrics.NetdevMTUBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "discovery_netdev_mtu_bytes",
+			Help: "MTU value of the local network device.",
+		},
+		[]string{"device"},
+	)
 
 	// Metrics have to be registered to be exposed:
 	prometheus.MustRegister(Metrics.Connections)
 	prometheus.MustRegister(Metrics.ConnectionState)
 	prometheus.MustRegister(Metrics.EntriesTotal)
 	prometheus.MustRegister(Metrics.DiscoveryLogPageCount)
+	prometheus.MustRegister(Metrics.NetdevMTUBytes)
 }

--- a/metrics/netdev.go
+++ b/metrics/netdev.go
@@ -1,0 +1,77 @@
+// Copyright 2016--2026 Lightbits Labs Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// you may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/procfs/sysfs"
+	"github.com/sirupsen/logrus"
+)
+
+// netdevMTUCollectionInterval is how often the netdev MTU gauge is refreshed.
+const netdevMTUCollectionInterval = 30 * time.Second
+
+// UpdateNetdevMTU reads the MTU of every local network device from sysfs and
+// updates the NetdevMTUBytes gauge. A device whose MTU can't be read (e.g. it
+// disappeared, or the attribute isn't supported) is skipped rather than
+// failing the whole update.
+func UpdateNetdevMTU(fs sysfs.FS) error {
+	devices, err := fs.NetClassDevices()
+	if err != nil {
+		return err
+	}
+	for _, dev := range devices {
+		iface, err := fs.NetClassByIface(dev)
+		if err != nil {
+			logrus.WithError(err).WithField("device", dev).Debug("could not read sysfs net class info for device")
+			continue
+		}
+		if iface.MTU == nil {
+			continue
+		}
+		Metrics.NetdevMTUBytes.WithLabelValues(dev).Set(float64(*iface.MTU))
+	}
+	return nil
+}
+
+// RunNetdevMTUCollector periodically refreshes the netdev MTU gauge until ctx
+// is cancelled. Intended to be run in its own goroutine for the lifetime of
+// the application.
+func RunNetdevMTUCollector(ctx context.Context) {
+	fs, err := sysfs.NewDefaultFS()
+	if err != nil {
+		logrus.WithError(err).Warn("could not open sysfs, netdev MTU metric will not be collected")
+		return
+	}
+
+	if err := UpdateNetdevMTU(fs); err != nil {
+		logrus.WithError(err).Warn("could not collect netdev MTU metrics")
+	}
+
+	ticker := time.NewTicker(netdevMTUCollectionInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := UpdateNetdevMTU(fs); err != nil {
+				logrus.WithError(err).Warn("could not collect netdev MTU metrics")
+			}
+		}
+	}
+}

--- a/metrics/netdev_test.go
+++ b/metrics/netdev_test.go
@@ -1,0 +1,102 @@
+// Copyright 2016--2026 Lightbits Labs Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// you may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/procfs/sysfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestSysfs builds a sysfs.FS rooted at a temp dir containing
+// /class/net/<device>/mtu for each entry in mtuByDevice. An empty mtu value
+// means the device directory is created without an mtu file, simulating an
+// unreadable/unsupported attribute.
+func newTestSysfs(t *testing.T, mtuByDevice map[string]string) sysfs.FS {
+	t.Helper()
+	root := t.TempDir()
+	for dev, mtu := range mtuByDevice {
+		devDir := filepath.Join(root, "class", "net", dev)
+		require.NoError(t, os.MkdirAll(devDir, 0o755))
+		if mtu != "" {
+			require.NoError(t, os.WriteFile(filepath.Join(devDir, "mtu"), []byte(mtu), 0o644))
+		}
+	}
+	fs, err := sysfs.NewFS(root)
+	require.NoError(t, err)
+	return fs
+}
+
+// collectNetdevMTUMetrics reads back the current values of the
+// NetdevMTUBytes gauge, keyed by the "device" label.
+func collectNetdevMTUMetrics(t *testing.T) map[string]float64 {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 64)
+	Metrics.NetdevMTUBytes.Collect(ch)
+	close(ch)
+
+	values := map[string]float64{}
+	for m := range ch {
+		pb := &dto.Metric{}
+		require.NoError(t, m.Write(pb))
+		var device string
+		for _, lp := range pb.GetLabel() {
+			if lp.GetName() == "device" {
+				device = lp.GetValue()
+			}
+		}
+		values[device] = pb.GetGauge().GetValue()
+	}
+	return values
+}
+
+func TestUpdateNetdevMTU(t *testing.T) {
+	Metrics.NetdevMTUBytes.Reset()
+	fs := newTestSysfs(t, map[string]string{
+		"lo":   "65536\n",
+		"eth0": "1500\n",
+	})
+
+	require.NoError(t, UpdateNetdevMTU(fs))
+
+	assert.Equal(t, map[string]float64{"lo": 65536, "eth0": 1500}, collectNetdevMTUMetrics(t))
+}
+
+func TestUpdateNetdevMTUSkipsUnreadableAttribute(t *testing.T) {
+	Metrics.NetdevMTUBytes.Reset()
+	fs := newTestSysfs(t, map[string]string{
+		"lo":   "65536\n",
+		"eth0": "", // directory exists but has no mtu file
+	})
+
+	require.NoError(t, UpdateNetdevMTU(fs))
+
+	assert.Equal(t, map[string]float64{"lo": 65536}, collectNetdevMTUMetrics(t))
+}
+
+func TestUpdateNetdevMTUMissingClassNetDir(t *testing.T) {
+	Metrics.NetdevMTUBytes.Reset()
+	// The sysfs root exists, but "class/net" under it does not.
+	fs, err := sysfs.NewFS(t.TempDir())
+	require.NoError(t, err)
+
+	assert.Error(t, UpdateNetdevMTU(fs))
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/.gitignore
+++ b/vendor/github.com/prometheus/procfs/sysfs/.gitignore
@@ -1,0 +1,1 @@
+fixtures/

--- a/vendor/github.com/prometheus/procfs/sysfs/class_cooling_device.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_cooling_device.go
@@ -1,0 +1,91 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// ClassCoolingDeviceStats contains info from files in /sys/class/thermal/cooling_device[0-9]*
+// for a single device.
+// https://www.kernel.org/doc/Documentation/thermal/sysfs-api.txt
+type ClassCoolingDeviceStats struct {
+	Name     string // The name of the cooling device.
+	Type     string // Type of the cooling device(processor/fan/...)
+	MaxState int64  // Maximum cooling state of the cooling device
+	CurState int64  // Current cooling state of the cooling device
+}
+
+func (fs FS) ClassCoolingDeviceStats() ([]ClassCoolingDeviceStats, error) {
+	cds, err := filepath.Glob(fs.sys.Path("class/thermal/cooling_device[0-9]*"))
+	if err != nil {
+		return []ClassCoolingDeviceStats{}, err
+	}
+
+	var coolingDeviceStats = ClassCoolingDeviceStats{}
+	stats := make([]ClassCoolingDeviceStats, len(cds))
+	for i, cd := range cds {
+		cdName := strings.TrimPrefix(filepath.Base(cd), "cooling_device")
+
+		coolingDeviceStats, err = parseCoolingDeviceStats(cd)
+		if err != nil {
+			return []ClassCoolingDeviceStats{}, err
+		}
+
+		coolingDeviceStats.Name = cdName
+		stats[i] = coolingDeviceStats
+	}
+	return stats, nil
+}
+
+func parseCoolingDeviceStats(cd string) (ClassCoolingDeviceStats, error) {
+	cdType, err := util.SysReadFile(filepath.Join(cd, "type"))
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+
+	cdMaxStateString, err := util.SysReadFile(filepath.Join(cd, "max_state"))
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+	cdMaxStateInt, err := strconv.ParseInt(cdMaxStateString, 10, 64)
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+
+	// cur_state can be -1, eg intel powerclamp
+	// https://www.kernel.org/doc/Documentation/thermal/intel_powerclamp.txt
+	cdCurStateString, err := util.SysReadFile(filepath.Join(cd, "cur_state"))
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+
+	cdCurStateInt, err := strconv.ParseInt(cdCurStateString, 10, 64)
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+
+	return ClassCoolingDeviceStats{
+		Type:     cdType,
+		MaxState: cdMaxStateInt,
+		CurState: cdCurStateInt,
+	}, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_dmi.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_dmi.go
@@ -1,0 +1,131 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const dmiClassPath = "class/dmi/id"
+
+// DMIClass contains info from files in /sys/class/dmi/id.
+type DMIClass struct {
+	BiosDate        *string // /sys/class/dmi/id/bios_date
+	BiosRelease     *string // /sys/class/dmi/id/bios_release
+	BiosVendor      *string // /sys/class/dmi/id/bios_vendor
+	BiosVersion     *string // /sys/class/dmi/id/bios_version
+	BoardAssetTag   *string // /sys/class/dmi/id/board_asset_tag
+	BoardName       *string // /sys/class/dmi/id/board_name
+	BoardSerial     *string // /sys/class/dmi/id/board_serial
+	BoardVendor     *string // /sys/class/dmi/id/board_vendor
+	BoardVersion    *string // /sys/class/dmi/id/board_version
+	ChassisAssetTag *string // /sys/class/dmi/id/chassis_asset_tag
+	ChassisSerial   *string // /sys/class/dmi/id/chassis_serial
+	ChassisType     *string // /sys/class/dmi/id/chassis_type
+	ChassisVendor   *string // /sys/class/dmi/id/chassis_vendor
+	ChassisVersion  *string // /sys/class/dmi/id/chassis_version
+	ProductFamily   *string // /sys/class/dmi/id/product_family
+	ProductName     *string // /sys/class/dmi/id/product_name
+	ProductSerial   *string // /sys/class/dmi/id/product_serial
+	ProductSKU      *string // /sys/class/dmi/id/product_sku
+	ProductUUID     *string // /sys/class/dmi/id/product_uuid
+	ProductVersion  *string // /sys/class/dmi/id/product_version
+	SystemVendor    *string // /sys/class/dmi/id/sys_vendor
+}
+
+// DMIClass returns Desktop Management Interface (DMI) information read from /sys/class/dmi.
+func (fs FS) DMIClass() (*DMIClass, error) {
+	path := fs.sys.Path(dmiClassPath)
+
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %q: %w", path, err)
+	}
+
+	var dmi DMIClass
+	for _, f := range files {
+		if !f.Type().IsRegular() {
+			continue
+		}
+
+		name := f.Name()
+		if name == "modalias" || name == "uevent" {
+			continue
+		}
+
+		filename := filepath.Join(path, name)
+		value, err := util.SysReadFile(filename)
+		if err != nil {
+			if os.IsPermission(err) {
+				// Only root is allowed to read the serial and product_uuid files!
+				continue
+			}
+			return nil, fmt.Errorf("failed to read file %q: %w", filename, err)
+		}
+
+		switch name {
+		case "bios_date":
+			dmi.BiosDate = &value
+		case "bios_release":
+			dmi.BiosRelease = &value
+		case "bios_vendor":
+			dmi.BiosVendor = &value
+		case "bios_version":
+			dmi.BiosVersion = &value
+		case "board_asset_tag":
+			dmi.BoardAssetTag = &value
+		case "board_name":
+			dmi.BoardName = &value
+		case "board_serial":
+			dmi.BoardSerial = &value
+		case "board_vendor":
+			dmi.BoardVendor = &value
+		case "board_version":
+			dmi.BoardVersion = &value
+		case "chassis_asset_tag":
+			dmi.ChassisAssetTag = &value
+		case "chassis_serial":
+			dmi.ChassisSerial = &value
+		case "chassis_type":
+			dmi.ChassisType = &value
+		case "chassis_vendor":
+			dmi.ChassisVendor = &value
+		case "chassis_version":
+			dmi.ChassisVersion = &value
+		case "product_family":
+			dmi.ProductFamily = &value
+		case "product_name":
+			dmi.ProductName = &value
+		case "product_serial":
+			dmi.ProductSerial = &value
+		case "product_sku":
+			dmi.ProductSKU = &value
+		case "product_uuid":
+			dmi.ProductUUID = &value
+		case "product_version":
+			dmi.ProductVersion = &value
+		case "sys_vendor":
+			dmi.SystemVendor = &value
+		}
+	}
+
+	return &dmi, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_drm.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_drm.go
@@ -1,0 +1,27 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"path/filepath"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+func readDRMCardField(card, field string) (string, error) {
+	return util.SysReadFile(filepath.Join(card, "device", field))
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_drm_amdgpu.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_drm_amdgpu.go
@@ -1,0 +1,122 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"syscall"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const (
+	// Supported device drivers.
+	deviceDriverAMDGPU = "amdgpu"
+)
+
+// ClassDRMCardAMDGPUStats contains info from files in
+// /sys/class/drm/card<card>/device for a single amdgpu card.
+// Not all cards expose all metrics.
+// https://www.kernel.org/doc/html/latest/gpu/amdgpu.html
+type ClassDRMCardAMDGPUStats struct {
+	Name                          string // The card name.
+	GPUBusyPercent                uint64 // How busy the GPU is as a percentage.
+	MemoryGTTSize                 uint64 // The size of the graphics translation table (GTT) block in bytes.
+	MemoryGTTUsed                 uint64 // The used amount of the graphics translation table (GTT) block in bytes.
+	MemoryVisibleVRAMSize         uint64 // The size of visible VRAM in bytes.
+	MemoryVisibleVRAMUsed         uint64 // The used amount of visible VRAM in bytes.
+	MemoryVRAMSize                uint64 // The size of VRAM in bytes.
+	MemoryVRAMUsed                uint64 // The used amount of VRAM in bytes.
+	MemoryVRAMVendor              string // The VRAM vendor name.
+	PowerDPMForcePerformanceLevel string // The current power performance level.
+	UniqueID                      string // The unique ID of the GPU that will persist from machine to machine.
+}
+
+// ClassDRMCardAMDGPUStats returns DRM card metrics for all amdgpu cards.
+func (fs FS) ClassDRMCardAMDGPUStats() ([]ClassDRMCardAMDGPUStats, error) {
+	cards, err := filepath.Glob(fs.sys.Path("class/drm/card[0-9]"))
+	if err != nil {
+		return nil, err
+	}
+
+	var stats []ClassDRMCardAMDGPUStats
+	for _, card := range cards {
+		cardStats, err := parseClassDRMAMDGPUCard(card)
+		if err != nil {
+			if errors.Is(err, syscall.ENODATA) {
+				continue
+			}
+			return nil, err
+		}
+		cardStats.Name = filepath.Base(card)
+		stats = append(stats, cardStats)
+	}
+	return stats, nil
+}
+
+func parseClassDRMAMDGPUCard(card string) (ClassDRMCardAMDGPUStats, error) {
+	uevent, err := util.SysReadFile(filepath.Join(card, "device/uevent"))
+	if err != nil {
+		return ClassDRMCardAMDGPUStats{}, err
+	}
+
+	match, err := regexp.MatchString(fmt.Sprintf("DRIVER=%s", deviceDriverAMDGPU), uevent)
+	if err != nil {
+		return ClassDRMCardAMDGPUStats{}, err
+	}
+	if !match {
+		return ClassDRMCardAMDGPUStats{}, nil
+	}
+
+	stats := ClassDRMCardAMDGPUStats{Name: card}
+	// Read only specific files for faster data gathering.
+	if v, err := readDRMCardField(card, "gpu_busy_percent"); err == nil {
+		stats.GPUBusyPercent = *util.NewValueParser(v).PUInt64()
+	}
+	if v, err := readDRMCardField(card, "mem_info_gtt_total"); err == nil {
+		stats.MemoryGTTSize = *util.NewValueParser(v).PUInt64()
+	}
+	if v, err := readDRMCardField(card, "mem_info_gtt_used"); err == nil {
+		stats.MemoryGTTUsed = *util.NewValueParser(v).PUInt64()
+	}
+	if v, err := readDRMCardField(card, "mem_info_vis_vram_total"); err == nil {
+		stats.MemoryVisibleVRAMSize = *util.NewValueParser(v).PUInt64()
+	}
+	if v, err := readDRMCardField(card, "mem_info_vis_vram_used"); err == nil {
+		stats.MemoryVisibleVRAMUsed = *util.NewValueParser(v).PUInt64()
+	}
+	if v, err := readDRMCardField(card, "mem_info_vram_total"); err == nil {
+		stats.MemoryVRAMSize = *util.NewValueParser(v).PUInt64()
+	}
+	if v, err := readDRMCardField(card, "mem_info_vram_used"); err == nil {
+		stats.MemoryVRAMUsed = *util.NewValueParser(v).PUInt64()
+	}
+	if v, err := readDRMCardField(card, "mem_info_vram_vendor"); err == nil {
+		stats.MemoryVRAMVendor = v
+	}
+	if v, err := readDRMCardField(card, "power_dpm_force_performance_level"); err == nil {
+		stats.PowerDPMForcePerformanceLevel = v
+	}
+	if v, err := readDRMCardField(card, "unique_id"); err == nil {
+		stats.UniqueID = v
+	}
+
+	return stats, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_fibrechannel.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_fibrechannel.go
@@ -1,0 +1,249 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const fibrechannelClassPath = "class/fc_host"
+
+type FibreChannelCounters struct {
+	DumpedFrames          uint64 // /sys/class/fc_host/<Name>/statistics/dumped_frames
+	ErrorFrames           uint64 // /sys/class/fc_host/<Name>/statistics/error_frames
+	InvalidCRCCount       uint64 // /sys/class/fc_host/<Name>/statistics/invalid_crc_count
+	RXFrames              uint64 // /sys/class/fc_host/<Name>/statistics/rx_frames
+	RXWords               uint64 // /sys/class/fc_host/<Name>/statistics/rx_words
+	TXFrames              uint64 // /sys/class/fc_host/<Name>/statistics/tx_frames
+	TXWords               uint64 // /sys/class/fc_host/<Name>/statistics/tx_words
+	SecondsSinceLastReset uint64 // /sys/class/fc_host/<Name>/statistics/seconds_since_last_reset
+	InvalidTXWordCount    uint64 // /sys/class/fc_host/<Name>/statistics/invalid_tx_word_count
+	LinkFailureCount      uint64 // /sys/class/fc_host/<Name>/statistics/link_failure_count
+	LossOfSyncCount       uint64 // /sys/class/fc_host/<Name>/statistics/loss_of_sync_count
+	LossOfSignalCount     uint64 // /sys/class/fc_host/<Name>/statistics/loss_of_signal_count
+	NosCount              uint64 // /sys/class/fc_host/<Name>/statistics/nos_count
+	FCPPacketAborts       uint64 // / sys/class/fc_host/<Name>/statistics/fcp_packet_aborts
+}
+
+type FibreChannelHost struct {
+	Name             string               // /sys/class/fc_host/<Name>
+	Speed            string               // /sys/class/fc_host/<Name>/speed
+	PortState        string               // /sys/class/fc_host/<Name>/port_state
+	PortType         string               // /sys/class/fc_host/<Name>/port_type
+	SymbolicName     string               // /sys/class/fc_host/<Name>/symbolic_name
+	NodeName         string               // /sys/class/fc_host/<Name>/node_name
+	PortID           string               // /sys/class/fc_host/<Name>/port_id
+	PortName         string               // /sys/class/fc_host/<Name>/port_name
+	FabricName       string               // /sys/class/fc_host/<Name>/fabric_name
+	DevLossTMO       string               // /sys/class/fc_host/<Name>/dev_loss_tmo
+	SupportedClasses string               // /sys/class/fc_host/<Name>/supported_classes
+	SupportedSpeeds  string               // /sys/class/fc_host/<Name>/supported_speeds
+	Counters         FibreChannelCounters // /sys/class/fc_host/<Name>/statistics/*
+}
+
+type FibreChannelClass map[string]FibreChannelHost
+
+// FibreChannelClass parses everything in /sys/class/fc_host.
+func (fs FS) FibreChannelClass() (FibreChannelClass, error) {
+	path := fs.sys.Path(fibrechannelClassPath)
+
+	dirs, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fcc := make(FibreChannelClass, len(dirs))
+	for _, d := range dirs {
+		host, err := fs.parseFibreChannelHost(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		fcc[host.Name] = *host
+	}
+
+	return fcc, nil
+}
+
+// Parse a single FC host.
+func (fs FS) parseFibreChannelHost(name string) (*FibreChannelHost, error) {
+	path := fs.sys.Path(fibrechannelClassPath, name)
+	host := FibreChannelHost{Name: name}
+
+	for _, f := range [...]string{"speed", "port_state", "port_type", "node_name", "port_id", "port_name", "fabric_name", "dev_loss_tmo", "symbolic_name", "supported_classes", "supported_speeds"} {
+		name := filepath.Join(path, f)
+		value, err := util.SysReadFile(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+		}
+
+		switch f {
+		case "speed":
+			host.Speed = value
+		case "port_state":
+			host.PortState = value
+		case "port_type":
+			host.PortType = value
+		case "node_name":
+			if len(value) > 2 {
+				value = value[2:]
+			}
+			host.NodeName = value
+		case "port_id":
+			if len(value) > 2 {
+				value = value[2:]
+			}
+			host.PortID = value
+		case "port_name":
+			if len(value) > 2 {
+				value = value[2:]
+			}
+			host.PortName = value
+		case "fabric_name":
+			if len(value) > 2 {
+				value = value[2:]
+			}
+			host.FabricName = value
+		case "dev_loss_tmo":
+			host.DevLossTMO = value
+		case "supported_classes":
+			host.SupportedClasses = value
+		case "supported_speeds":
+			host.SupportedSpeeds = value
+		case "symbolic_name":
+			host.SymbolicName = value
+		}
+	}
+
+	counters, err := parseFibreChannelStatistics(path)
+	if err != nil {
+		return nil, err
+	}
+	host.Counters = *counters
+
+	return &host, nil
+}
+
+// parseFibreChannelStatistics parses metrics from a single FC host.
+func parseFibreChannelStatistics(hostPath string) (*FibreChannelCounters, error) {
+	var counters FibreChannelCounters
+
+	path := filepath.Join(hostPath, "statistics")
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range files {
+		if !f.Type().IsRegular() || f.Name() == "reset_statistics" {
+			continue
+		}
+
+		name := filepath.Join(path, f.Name())
+		value, err := util.SysReadFile(name)
+		if err != nil {
+			// there are some write-only files in this directory; we can safely skip over them
+			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+		}
+
+		vp := util.NewValueParser(value)
+
+		// Below switch was automatically generated. Don't need everything in there yet, so the unwanted bits are commented out.
+		switch f.Name() {
+		case "dumped_frames":
+			counters.DumpedFrames = *vp.PUInt64()
+		case "error_frames":
+			counters.ErrorFrames = *vp.PUInt64()
+		/*
+			case "fc_no_free_exch":
+				counters.FcNoFreeExch = *vp.PUInt64()
+			case "fc_no_free_exch_xid":
+				counters.FcNoFreeExchXid = *vp.PUInt64()
+			case "fc_non_bls_resp":
+				counters.FcNonBlsResp = *vp.PUInt64()
+			case "fc_seq_not_found":
+				counters.FcSeqNotFound = *vp.PUInt64()
+			case "fc_xid_busy":
+				counters.FcXidBusy = *vp.PUInt64()
+			case "fc_xid_not_found":
+				counters.FcXidNotFound = *vp.PUInt64()
+			case "fcp_control_requests":
+				counters.FcpControlRequests = *vp.PUInt64()
+			case "fcp_frame_alloc_failures":
+				counters.FcpFrameAllocFailures = *vp.PUInt64()
+			case "fcp_input_megabytes":
+				counters.FcpInputMegabytes = *vp.PUInt64()
+			case "fcp_input_requests":
+				counters.FcpInputRequests = *vp.PUInt64()
+			case "fcp_output_megabytes":
+				counters.FcpOutputMegabytes = *vp.PUInt64()
+			case "fcp_output_requests":
+				counters.FcpOutputRequests = *vp.PUInt64()
+		*/
+		case "fcp_packet_aborts":
+			counters.FCPPacketAborts = *vp.PUInt64()
+			/*
+				case "fcp_packet_alloc_failures":
+					counters.FcpPacketAllocFailures = *vp.PUInt64()
+			*/
+		case "invalid_tx_word_count":
+			counters.InvalidTXWordCount = *vp.PUInt64()
+		case "invalid_crc_count":
+			counters.InvalidCRCCount = *vp.PUInt64()
+		case "link_failure_count":
+			counters.LinkFailureCount = *vp.PUInt64()
+		/*
+			case "lip_count":
+					counters.LipCount = *vp.PUInt64()
+		*/
+		case "loss_of_signal_count":
+			counters.LossOfSignalCount = *vp.PUInt64()
+		case "loss_of_sync_count":
+			counters.LossOfSyncCount = *vp.PUInt64()
+		case "nos_count":
+			counters.NosCount = *vp.PUInt64()
+		/*
+			case "prim_seq_protocol_err_count":
+				counters.PrimSeqProtocolErrCount = *vp.PUInt64()
+		*/
+		case "rx_frames":
+			counters.RXFrames = *vp.PUInt64()
+		case "rx_words":
+			counters.RXWords = *vp.PUInt64()
+		case "seconds_since_last_reset":
+			counters.SecondsSinceLastReset = *vp.PUInt64()
+		case "tx_frames":
+			counters.TXFrames = *vp.PUInt64()
+		case "tx_words":
+			counters.TXWords = *vp.PUInt64()
+		}
+
+		if err := vp.Err(); err != nil {
+			return nil, err
+		}
+
+	}
+
+	return &counters, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_infiniband.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_infiniband.go
@@ -1,0 +1,406 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const infinibandClassPath = "class/infiniband"
+
+// InfiniBandCounters contains counter values from files in
+// /sys/class/infiniband/<Name>/ports/<Port>/counters or
+// /sys/class/infiniband/<Name>/ports/<Port>/counters_ext
+// for a single port of one InfiniBand device.
+type InfiniBandCounters struct {
+	LegacyPortMulticastRcvPackets  *uint64 // counters_ext/port_multicast_rcv_packets
+	LegacyPortMulticastXmitPackets *uint64 // counters_ext/port_multicast_xmit_packets
+	LegacyPortRcvData64            *uint64 // counters_ext/port_rcv_data_64
+	LegacyPortRcvPackets64         *uint64 // counters_ext/port_rcv_packets_64
+	LegacyPortUnicastRcvPackets    *uint64 // counters_ext/port_unicast_rcv_packets
+	LegacyPortUnicastXmitPackets   *uint64 // counters_ext/port_unicast_xmit_packets
+	LegacyPortXmitData64           *uint64 // counters_ext/port_xmit_data_64
+	LegacyPortXmitPackets64        *uint64 // counters_ext/port_xmit_packets_64
+
+	ExcessiveBufferOverrunErrors *uint64 // counters/excessive_buffer_overrun_errors
+	LinkDowned                   *uint64 // counters/link_downed
+	LinkErrorRecovery            *uint64 // counters/link_error_recovery
+	LocalLinkIntegrityErrors     *uint64 // counters/local_link_integrity_errors
+	MulticastRcvPackets          *uint64 // counters/multicast_rcv_packets
+	MulticastXmitPackets         *uint64 // counters/multicast_xmit_packets
+	PortRcvConstraintErrors      *uint64 // counters/port_rcv_constraint_errors
+	PortRcvData                  *uint64 // counters/port_rcv_data
+	PortRcvDiscards              *uint64 // counters/port_rcv_discards
+	PortRcvErrors                *uint64 // counters/port_rcv_errors
+	PortRcvPackets               *uint64 // counters/port_rcv_packets
+	PortRcvRemotePhysicalErrors  *uint64 // counters/port_rcv_remote_physical_errors
+	PortRcvSwitchRelayErrors     *uint64 // counters/port_rcv_switch_relay_errors
+	PortXmitConstraintErrors     *uint64 // counters/port_xmit_constraint_errors
+	PortXmitData                 *uint64 // counters/port_xmit_data
+	PortXmitDiscards             *uint64 // counters/port_xmit_discards
+	PortXmitPackets              *uint64 // counters/port_xmit_packets
+	PortXmitWait                 *uint64 // counters/port_xmit_wait
+	SymbolError                  *uint64 // counters/symbol_error
+	UnicastRcvPackets            *uint64 // counters/unicast_rcv_packets
+	UnicastXmitPackets           *uint64 // counters/unicast_xmit_packets
+	VL15Dropped                  *uint64 // counters/VL15_dropped
+}
+
+// InfiniBandPort contains info from files in
+// /sys/class/infiniband/<Name>/ports/<Port>
+// for a single port of one InfiniBand device.
+type InfiniBandPort struct {
+	Name        string
+	Port        uint
+	State       string // String representation from /sys/class/infiniband/<Name>/ports/<Port>/state
+	StateID     uint   // ID from /sys/class/infiniband/<Name>/ports/<Port>/state
+	PhysState   string // String representation from /sys/class/infiniband/<Name>/ports/<Port>/phys_state
+	PhysStateID uint   // String representation from /sys/class/infiniband/<Name>/ports/<Port>/phys_state
+	Rate        uint64 // in bytes/second from /sys/class/infiniband/<Name>/ports/<Port>/rate
+	Counters    InfiniBandCounters
+}
+
+// InfiniBandDevice contains info from files in /sys/class/infiniband for a
+// single InfiniBand device.
+type InfiniBandDevice struct {
+	Name            string
+	BoardID         string // /sys/class/infiniband/<Name>/board_id
+	FirmwareVersion string // /sys/class/infiniband/<Name>/fw_ver
+	HCAType         string // /sys/class/infiniband/<Name>/hca_type
+	Ports           map[uint]InfiniBandPort
+}
+
+// InfiniBandClass is a collection of every InfiniBand device in
+// /sys/class/infiniband.
+//
+// The map keys are the names of the InfiniBand devices.
+type InfiniBandClass map[string]InfiniBandDevice
+
+// InfiniBandClass returns info for all InfiniBand devices read from
+// /sys/class/infiniband.
+func (fs FS) InfiniBandClass() (InfiniBandClass, error) {
+	path := fs.sys.Path(infinibandClassPath)
+
+	dirs, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ibc := make(InfiniBandClass, len(dirs))
+	for _, d := range dirs {
+		device, err := fs.parseInfiniBandDevice(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		ibc[device.Name] = *device
+	}
+
+	return ibc, nil
+}
+
+// Parse one InfiniBand device.
+func (fs FS) parseInfiniBandDevice(name string) (*InfiniBandDevice, error) {
+	path := fs.sys.Path(infinibandClassPath, name)
+	device := InfiniBandDevice{Name: name}
+
+	for _, f := range [...]string{"board_id", "fw_ver", "hca_type"} {
+		name := filepath.Join(path, f)
+		value, err := util.SysReadFile(name)
+		if err != nil {
+			// Not all InfiniBand drivers provide hca_type.
+			if os.IsNotExist(err) && (f == "hca_type") {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+		}
+
+		switch f {
+		case "board_id":
+			device.BoardID = value
+		case "fw_ver":
+			device.FirmwareVersion = value
+		case "hca_type":
+			device.HCAType = value
+		}
+	}
+
+	portsPath := filepath.Join(path, "ports")
+	ports, err := os.ReadDir(portsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list InfiniBand ports at %q: %w", portsPath, err)
+	}
+
+	device.Ports = make(map[uint]InfiniBandPort, len(ports))
+	for _, d := range ports {
+		port, err := fs.parseInfiniBandPort(name, d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		device.Ports[port.Port] = *port
+	}
+
+	return &device, nil
+}
+
+// Parse InfiniBand state. Expected format: "<id>: <string-representation>".
+func parseState(s string) (uint, string, error) {
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return 0, "", fmt.Errorf("failed to split %s into 'ID: NAME'", s)
+	}
+	name := strings.TrimSpace(parts[1])
+	value, err := strconv.ParseUint(strings.TrimSpace(parts[0]), 10, 32)
+	if err != nil {
+		return 0, name, fmt.Errorf("failed to convert %s into uint", strings.TrimSpace(parts[0]))
+	}
+	id := uint(value)
+	return id, name, nil
+}
+
+// Parse rate (example: "100 Gb/sec (4X EDR)") and return it as bytes/second.
+func parseRate(s string) (uint64, error) {
+	parts := strings.SplitAfterN(s, " ", 2)
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("failed to split %q", s)
+	}
+	value, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert %s into uint", strings.TrimSpace(parts[0]))
+	}
+	// Convert Gb/s into bytes/s
+	rate := uint64(value * 125000000)
+	return rate, nil
+}
+
+// parseInfiniBandPort scans predefined files in /sys/class/infiniband/<device>/ports/<port>
+// directory and gets their contents.
+func (fs FS) parseInfiniBandPort(name string, port string) (*InfiniBandPort, error) {
+	portNumber, err := strconv.ParseUint(port, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert %s into uint", port)
+	}
+	ibp := InfiniBandPort{Name: name, Port: uint(portNumber)}
+
+	portPath := fs.sys.Path(infinibandClassPath, name, "ports", port)
+	content, err := os.ReadFile(filepath.Join(portPath, "state"))
+	if err != nil {
+		return nil, err
+	}
+	id, name, err := parseState(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("could not parse state file in %q: %w", portPath, err)
+	}
+	ibp.State = name
+	ibp.StateID = id
+
+	content, err = os.ReadFile(filepath.Join(portPath, "phys_state"))
+	if err != nil {
+		return nil, err
+	}
+	id, name, err = parseState(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("could not parse phys_state file in %q: %w", portPath, err)
+	}
+	ibp.PhysState = name
+	ibp.PhysStateID = id
+
+	content, err = os.ReadFile(filepath.Join(portPath, "rate"))
+	if err != nil {
+		return nil, err
+	}
+	ibp.Rate, err = parseRate(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("could not parse rate file in %q: %w", portPath, err)
+	}
+
+	counters, err := parseInfiniBandCounters(portPath)
+	if err != nil {
+		return nil, err
+	}
+	ibp.Counters = *counters
+
+	return &ibp, nil
+}
+
+func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
+	var counters InfiniBandCounters
+
+	path := filepath.Join(portPath, "counters")
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range files {
+		if !f.Type().IsRegular() {
+			continue
+		}
+
+		name := filepath.Join(path, f.Name())
+		value, err := util.SysReadFile(name)
+		if err != nil {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+		}
+
+		// According to Mellanox, the metrics port_rcv_data, port_xmit_data,
+		// port_rcv_data_64, and port_xmit_data_64 "are divided by 4 unconditionally"
+		// as they represent the amount of data being transmitted and received per lane.
+		// Mellanox cards have 4 lanes per port, so all values must be multiplied by 4
+		// to get the expected value.
+
+		vp := util.NewValueParser(value)
+
+		switch f.Name() {
+		case "excessive_buffer_overrun_errors":
+			counters.ExcessiveBufferOverrunErrors = vp.PUInt64()
+		case "link_downed":
+			counters.LinkDowned = vp.PUInt64()
+		case "link_error_recovery":
+			counters.LinkErrorRecovery = vp.PUInt64()
+		case "local_link_integrity_errors":
+			counters.LocalLinkIntegrityErrors = vp.PUInt64()
+		case "multicast_rcv_packets":
+			counters.MulticastRcvPackets = vp.PUInt64()
+		case "multicast_xmit_packets":
+			counters.MulticastXmitPackets = vp.PUInt64()
+		case "port_rcv_constraint_errors":
+			counters.PortRcvConstraintErrors = vp.PUInt64()
+		case "port_rcv_data":
+			counters.PortRcvData = vp.PUInt64()
+			if counters.PortRcvData != nil {
+				*counters.PortRcvData *= 4
+			}
+		case "port_rcv_discards":
+			counters.PortRcvDiscards = vp.PUInt64()
+		case "port_rcv_errors":
+			counters.PortRcvErrors = vp.PUInt64()
+		case "port_rcv_packets":
+			counters.PortRcvPackets = vp.PUInt64()
+		case "port_rcv_remote_physical_errors":
+			counters.PortRcvRemotePhysicalErrors = vp.PUInt64()
+		case "port_rcv_switch_relay_errors":
+			counters.PortRcvSwitchRelayErrors = vp.PUInt64()
+		case "port_xmit_constraint_errors":
+			counters.PortXmitConstraintErrors = vp.PUInt64()
+		case "port_xmit_data":
+			counters.PortXmitData = vp.PUInt64()
+			if counters.PortXmitData != nil {
+				*counters.PortXmitData *= 4
+			}
+		case "port_xmit_discards":
+			counters.PortXmitDiscards = vp.PUInt64()
+		case "port_xmit_packets":
+			counters.PortXmitPackets = vp.PUInt64()
+		case "port_xmit_wait":
+			counters.PortXmitWait = vp.PUInt64()
+		case "symbol_error":
+			counters.SymbolError = vp.PUInt64()
+		case "unicast_rcv_packets":
+			counters.UnicastRcvPackets = vp.PUInt64()
+		case "unicast_xmit_packets":
+			counters.UnicastXmitPackets = vp.PUInt64()
+		case "VL15_dropped":
+			counters.VL15Dropped = vp.PUInt64()
+		}
+
+		if err := vp.Err(); err != nil {
+			// Ugly workaround for handling https://github.com/prometheus/node_exporter/issues/966
+			// when counters are `N/A (not available)`.
+			// This was already patched and submitted, see
+			// https://www.spinics.net/lists/linux-rdma/msg68596.html
+			// Remove this as soon as the fix lands in the enterprise distros.
+			if strings.Contains(value, "N/A (no PMA)") {
+				continue
+			}
+			return nil, err
+		}
+	}
+
+	// Parse legacy counters
+	path = filepath.Join(portPath, "counters_ext")
+	files, err = os.ReadDir(path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	for _, f := range files {
+		if !f.Type().IsRegular() {
+			continue
+		}
+
+		name := filepath.Join(path, f.Name())
+		value, err := util.SysReadFile(name)
+		if err != nil {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+		}
+
+		vp := util.NewValueParser(value)
+
+		switch f.Name() {
+		case "port_multicast_rcv_packets":
+			counters.LegacyPortMulticastRcvPackets = vp.PUInt64()
+		case "port_multicast_xmit_packets":
+			counters.LegacyPortMulticastXmitPackets = vp.PUInt64()
+		case "port_rcv_data_64":
+			counters.LegacyPortRcvData64 = vp.PUInt64()
+			if counters.LegacyPortRcvData64 != nil {
+				*counters.LegacyPortRcvData64 *= 4
+			}
+		case "port_rcv_packets_64":
+			counters.LegacyPortRcvPackets64 = vp.PUInt64()
+		case "port_unicast_rcv_packets":
+			counters.LegacyPortUnicastRcvPackets = vp.PUInt64()
+		case "port_unicast_xmit_packets":
+			counters.LegacyPortUnicastXmitPackets = vp.PUInt64()
+		case "port_xmit_data_64":
+			counters.LegacyPortXmitData64 = vp.PUInt64()
+			if counters.LegacyPortXmitData64 != nil {
+				*counters.LegacyPortXmitData64 *= 4
+			}
+		case "port_xmit_packets_64":
+			counters.LegacyPortXmitPackets64 = vp.PUInt64()
+		}
+
+		if err := vp.Err(); err != nil {
+			// Ugly workaround for handling https://github.com/prometheus/node_exporter/issues/966
+			// when counters are `N/A (not available)`.
+			// This was already patched and submitted, see
+			// https://www.spinics.net/lists/linux-rdma/msg68596.html
+			// Remove this as soon as the fix lands in the enterprise distros.
+			if strings.Contains(value, "N/A (no PMA)") {
+				continue
+			}
+			return nil, err
+		}
+	}
+
+	return &counters, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_nvme.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_nvme.go
@@ -1,0 +1,90 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const nvmeClassPath = "class/nvme"
+
+// NVMeDevice contains info from files in /sys/class/nvme for a single NVMe device.
+type NVMeDevice struct {
+	Name             string
+	Serial           string // /sys/class/nvme/<Name>/serial
+	Model            string // /sys/class/nvme/<Name>/model
+	State            string // /sys/class/nvme/<Name>/state
+	FirmwareRevision string // /sys/class/nvme/<Name>/firmware_rev
+}
+
+// NVMeClass is a collection of every NVMe device in /sys/class/nvme.
+//
+// The map keys are the names of the NVMe devices.
+type NVMeClass map[string]NVMeDevice
+
+// NVMeClass returns info for all NVMe devices read from /sys/class/nvme.
+func (fs FS) NVMeClass() (NVMeClass, error) {
+	path := fs.sys.Path(nvmeClassPath)
+
+	dirs, err := os.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list NVMe devices at %q: %w", path, err)
+	}
+
+	nc := make(NVMeClass, len(dirs))
+	for _, d := range dirs {
+		device, err := fs.parseNVMeDevice(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		nc[device.Name] = *device
+	}
+
+	return nc, nil
+}
+
+// Parse one NVMe device.
+func (fs FS) parseNVMeDevice(name string) (*NVMeDevice, error) {
+	path := fs.sys.Path(nvmeClassPath, name)
+	device := NVMeDevice{Name: name}
+
+	for _, f := range [...]string{"firmware_rev", "model", "serial", "state"} {
+		name := filepath.Join(path, f)
+		value, err := util.SysReadFile(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+		}
+
+		switch f {
+		case "firmware_rev":
+			device.FirmwareRevision = value
+		case "model":
+			device.Model = value
+		case "serial":
+			device.Serial = value
+		case "state":
+			device.State = value
+		}
+	}
+
+	return &device, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_power_supply.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_power_supply.go
@@ -1,0 +1,296 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// PowerSupply contains info from files in /sys/class/power_supply for a
+// single power supply.
+type PowerSupply struct {
+	Name                     string // Power Supply Name
+	Authentic                *int64 // /sys/class/power_supply/<Name>/authentic
+	Calibrate                *int64 // /sys/class/power_supply/<Name>/calibrate
+	Capacity                 *int64 // /sys/class/power_supply/<Name>/capacity
+	CapacityAlertMax         *int64 // /sys/class/power_supply/<Name>/capacity_alert_max
+	CapacityAlertMin         *int64 // /sys/class/power_supply/<Name>/capacity_alert_min
+	CapacityLevel            string // /sys/class/power_supply/<Name>/capacity_level
+	ChargeAvg                *int64 // /sys/class/power_supply/<Name>/charge_avg
+	ChargeControlLimit       *int64 // /sys/class/power_supply/<Name>/charge_control_limit
+	ChargeControlLimitMax    *int64 // /sys/class/power_supply/<Name>/charge_control_limit_max
+	ChargeCounter            *int64 // /sys/class/power_supply/<Name>/charge_counter
+	ChargeEmpty              *int64 // /sys/class/power_supply/<Name>/charge_empty
+	ChargeEmptyDesign        *int64 // /sys/class/power_supply/<Name>/charge_empty_design
+	ChargeFull               *int64 // /sys/class/power_supply/<Name>/charge_full
+	ChargeFullDesign         *int64 // /sys/class/power_supply/<Name>/charge_full_design
+	ChargeNow                *int64 // /sys/class/power_supply/<Name>/charge_now
+	ChargeTermCurrent        *int64 // /sys/class/power_supply/<Name>/charge_term_current
+	ChargeType               string // /sys/class/power_supply/<Name>/charge_type
+	ConstantChargeCurrent    *int64 // /sys/class/power_supply/<Name>/constant_charge_current
+	ConstantChargeCurrentMax *int64 // /sys/class/power_supply/<Name>/constant_charge_current_max
+	ConstantChargeVoltage    *int64 // /sys/class/power_supply/<Name>/constant_charge_voltage
+	ConstantChargeVoltageMax *int64 // /sys/class/power_supply/<Name>/constant_charge_voltage_max
+	CurrentAvg               *int64 // /sys/class/power_supply/<Name>/current_avg
+	CurrentBoot              *int64 // /sys/class/power_supply/<Name>/current_boot
+	CurrentMax               *int64 // /sys/class/power_supply/<Name>/current_max
+	CurrentNow               *int64 // /sys/class/power_supply/<Name>/current_now
+	CycleCount               *int64 // /sys/class/power_supply/<Name>/cycle_count
+	EnergyAvg                *int64 // /sys/class/power_supply/<Name>/energy_avg
+	EnergyEmpty              *int64 // /sys/class/power_supply/<Name>/energy_empty
+	EnergyEmptyDesign        *int64 // /sys/class/power_supply/<Name>/energy_empty_design
+	EnergyFull               *int64 // /sys/class/power_supply/<Name>/energy_full
+	EnergyFullDesign         *int64 // /sys/class/power_supply/<Name>/energy_full_design
+	EnergyNow                *int64 // /sys/class/power_supply/<Name>/energy_now
+	Health                   string // /sys/class/power_supply/<Name>/health
+	InputCurrentLimit        *int64 // /sys/class/power_supply/<Name>/input_current_limit
+	Manufacturer             string // /sys/class/power_supply/<Name>/manufacturer
+	ModelName                string // /sys/class/power_supply/<Name>/model_name
+	Online                   *int64 // /sys/class/power_supply/<Name>/online
+	PowerAvg                 *int64 // /sys/class/power_supply/<Name>/power_avg
+	PowerNow                 *int64 // /sys/class/power_supply/<Name>/power_now
+	PrechargeCurrent         *int64 // /sys/class/power_supply/<Name>/precharge_current
+	Present                  *int64 // /sys/class/power_supply/<Name>/present
+	Scope                    string // /sys/class/power_supply/<Name>/scope
+	SerialNumber             string // /sys/class/power_supply/<Name>/serial_number
+	Status                   string // /sys/class/power_supply/<Name>/status
+	Technology               string // /sys/class/power_supply/<Name>/technology
+	Temp                     *int64 // /sys/class/power_supply/<Name>/temp
+	TempAlertMax             *int64 // /sys/class/power_supply/<Name>/temp_alert_max
+	TempAlertMin             *int64 // /sys/class/power_supply/<Name>/temp_alert_min
+	TempAmbient              *int64 // /sys/class/power_supply/<Name>/temp_ambient
+	TempAmbientMax           *int64 // /sys/class/power_supply/<Name>/temp_ambient_max
+	TempAmbientMin           *int64 // /sys/class/power_supply/<Name>/temp_ambient_min
+	TempMax                  *int64 // /sys/class/power_supply/<Name>/temp_max
+	TempMin                  *int64 // /sys/class/power_supply/<Name>/temp_min
+	TimeToEmptyAvg           *int64 // /sys/class/power_supply/<Name>/time_to_empty_avg
+	TimeToEmptyNow           *int64 // /sys/class/power_supply/<Name>/time_to_empty_now
+	TimeToFullAvg            *int64 // /sys/class/power_supply/<Name>/time_to_full_avg
+	TimeToFullNow            *int64 // /sys/class/power_supply/<Name>/time_to_full_now
+	Type                     string // /sys/class/power_supply/<Name>/type
+	UsbType                  string // /sys/class/power_supply/<Name>/usb_type
+	VoltageAvg               *int64 // /sys/class/power_supply/<Name>/voltage_avg
+	VoltageBoot              *int64 // /sys/class/power_supply/<Name>/voltage_boot
+	VoltageMax               *int64 // /sys/class/power_supply/<Name>/voltage_max
+	VoltageMaxDesign         *int64 // /sys/class/power_supply/<Name>/voltage_max_design
+	VoltageMin               *int64 // /sys/class/power_supply/<Name>/voltage_min
+	VoltageMinDesign         *int64 // /sys/class/power_supply/<Name>/voltage_min_design
+	VoltageNow               *int64 // /sys/class/power_supply/<Name>/voltage_now
+	VoltageOCV               *int64 // /sys/class/power_supply/<Name>/voltage_ocv
+}
+
+// PowerSupplyClass is a collection of every power supply in
+// /sys/class/power_supply.
+//
+// The map keys are the names of the power supplies.
+type PowerSupplyClass map[string]PowerSupply
+
+// PowerSupplyClass returns info for all power supplies read from
+// /sys/class/power_supply.
+func (fs FS) PowerSupplyClass() (PowerSupplyClass, error) {
+	path := fs.sys.Path("class/power_supply")
+
+	dirs, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	psc := make(PowerSupplyClass, len(dirs))
+	for _, d := range dirs {
+		ps, err := parsePowerSupply(filepath.Join(path, d.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		ps.Name = d.Name()
+		psc[d.Name()] = *ps
+	}
+
+	return psc, nil
+}
+
+func parsePowerSupply(path string) (*PowerSupply, error) {
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var ps PowerSupply
+	for _, f := range files {
+		if !f.Type().IsRegular() {
+			continue
+		}
+
+		name := filepath.Join(path, f.Name())
+		value, err := util.SysReadFile(name)
+		if err != nil {
+			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+		}
+
+		vp := util.NewValueParser(value)
+
+		switch f.Name() {
+		case "authentic":
+			ps.Authentic = vp.PInt64()
+		case "calibrate":
+			ps.Calibrate = vp.PInt64()
+		case "capacity":
+			ps.Capacity = vp.PInt64()
+		case "capacity_alert_max":
+			ps.CapacityAlertMax = vp.PInt64()
+		case "capacity_alert_min":
+			ps.CapacityAlertMin = vp.PInt64()
+		case "capacity_level":
+			ps.CapacityLevel = value
+		case "charge_avg":
+			ps.ChargeAvg = vp.PInt64()
+		case "charge_control_limit":
+			ps.ChargeControlLimit = vp.PInt64()
+		case "charge_control_limit_max":
+			ps.ChargeControlLimitMax = vp.PInt64()
+		case "charge_counter":
+			ps.ChargeCounter = vp.PInt64()
+		case "charge_empty":
+			ps.ChargeEmpty = vp.PInt64()
+		case "charge_empty_design":
+			ps.ChargeEmptyDesign = vp.PInt64()
+		case "charge_full":
+			ps.ChargeFull = vp.PInt64()
+		case "charge_full_design":
+			ps.ChargeFullDesign = vp.PInt64()
+		case "charge_now":
+			ps.ChargeNow = vp.PInt64()
+		case "charge_term_current":
+			ps.ChargeTermCurrent = vp.PInt64()
+		case "charge_type":
+			ps.ChargeType = value
+		case "constant_charge_current":
+			ps.ConstantChargeCurrent = vp.PInt64()
+		case "constant_charge_current_max":
+			ps.ConstantChargeCurrentMax = vp.PInt64()
+		case "constant_charge_voltage":
+			ps.ConstantChargeVoltage = vp.PInt64()
+		case "constant_charge_voltage_max":
+			ps.ConstantChargeVoltageMax = vp.PInt64()
+		case "current_avg":
+			ps.CurrentAvg = vp.PInt64()
+		case "current_boot":
+			ps.CurrentBoot = vp.PInt64()
+		case "current_max":
+			ps.CurrentMax = vp.PInt64()
+		case "current_now":
+			ps.CurrentNow = vp.PInt64()
+		case "cycle_count":
+			ps.CycleCount = vp.PInt64()
+		case "energy_avg":
+			ps.EnergyAvg = vp.PInt64()
+		case "energy_empty":
+			ps.EnergyEmpty = vp.PInt64()
+		case "energy_empty_design":
+			ps.EnergyEmptyDesign = vp.PInt64()
+		case "energy_full":
+			ps.EnergyFull = vp.PInt64()
+		case "energy_full_design":
+			ps.EnergyFullDesign = vp.PInt64()
+		case "energy_now":
+			ps.EnergyNow = vp.PInt64()
+		case "health":
+			ps.Health = value
+		case "input_current_limit":
+			ps.InputCurrentLimit = vp.PInt64()
+		case "manufacturer":
+			ps.Manufacturer = value
+		case "model_name":
+			ps.ModelName = value
+		case "online":
+			ps.Online = vp.PInt64()
+		case "power_avg":
+			ps.PowerAvg = vp.PInt64()
+		case "power_now":
+			ps.PowerNow = vp.PInt64()
+		case "precharge_current":
+			ps.PrechargeCurrent = vp.PInt64()
+		case "present":
+			ps.Present = vp.PInt64()
+		case "scope":
+			ps.Scope = value
+		case "serial_number":
+			ps.SerialNumber = value
+		case "status":
+			ps.Status = value
+		case "technology":
+			ps.Technology = value
+		case "temp":
+			ps.Temp = vp.PInt64()
+		case "temp_alert_max":
+			ps.TempAlertMax = vp.PInt64()
+		case "temp_alert_min":
+			ps.TempAlertMin = vp.PInt64()
+		case "temp_ambient":
+			ps.TempAmbient = vp.PInt64()
+		case "temp_ambient_max":
+			ps.TempAmbientMax = vp.PInt64()
+		case "temp_ambient_min":
+			ps.TempAmbientMin = vp.PInt64()
+		case "temp_max":
+			ps.TempMax = vp.PInt64()
+		case "temp_min":
+			ps.TempMin = vp.PInt64()
+		case "time_to_empty_avg":
+			ps.TimeToEmptyAvg = vp.PInt64()
+		case "time_to_empty_now":
+			ps.TimeToEmptyNow = vp.PInt64()
+		case "time_to_full_avg":
+			ps.TimeToFullAvg = vp.PInt64()
+		case "time_to_full_now":
+			ps.TimeToFullNow = vp.PInt64()
+		case "type":
+			ps.Type = value
+		case "usb_type":
+			ps.UsbType = value
+		case "voltage_avg":
+			ps.VoltageAvg = vp.PInt64()
+		case "voltage_boot":
+			ps.VoltageBoot = vp.PInt64()
+		case "voltage_max":
+			ps.VoltageMax = vp.PInt64()
+		case "voltage_max_design":
+			ps.VoltageMaxDesign = vp.PInt64()
+		case "voltage_min":
+			ps.VoltageMin = vp.PInt64()
+		case "voltage_min_design":
+			ps.VoltageMinDesign = vp.PInt64()
+		case "voltage_now":
+			ps.VoltageNow = vp.PInt64()
+		case "voltage_ocv":
+			ps.VoltageOCV = vp.PInt64()
+		}
+
+		if err := vp.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	return &ps, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_powercap.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_powercap.go
@@ -1,0 +1,112 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// RaplZone stores the information for one RAPL power zone.
+type RaplZone struct {
+	Name           string // name of RAPL zone from file "name"
+	Index          int    // index (different value for duplicate names)
+	Path           string // filesystem path of RaplZone
+	MaxMicrojoules uint64 // max RAPL microjoule value
+}
+
+// GetRaplZones returns a slice of RaplZones. When RAPL files are not present,
+// returns nil with error.
+// - https://www.kernel.org/doc/Documentation/power/powercap/powercap.txt
+func GetRaplZones(fs FS) ([]RaplZone, error) {
+	raplDir := fs.sys.Path("class/powercap")
+
+	files, err := os.ReadDir(raplDir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read class/powercap: %w", err)
+	}
+
+	var zones []RaplZone
+
+	// Count name usages to avoid duplicates (label them with an index).
+	countNameUsages := make(map[string]int)
+
+	// Loop through directory files searching for file "name" from subdirs.
+	for _, f := range files {
+		nameFile := filepath.Join(raplDir, f.Name(), "/name")
+		nameBytes, err := os.ReadFile(nameFile)
+		if err == nil {
+			// Add new rapl zone since name file was found.
+			name := strings.TrimSpace(string(nameBytes))
+
+			// get a pair of index and final name
+			index, name := getIndexAndName(countNameUsages,
+				name)
+
+			maxMicrojouleFilename := filepath.Join(raplDir, f.Name(),
+				"/max_energy_range_uj")
+			maxMicrojoules, err := util.ReadUintFromFile(maxMicrojouleFilename)
+			if err != nil {
+				return nil, err
+			}
+
+			zone := RaplZone{
+				Name:           name,
+				Index:          index,
+				Path:           filepath.Join(raplDir, f.Name()),
+				MaxMicrojoules: maxMicrojoules,
+			}
+
+			zones = append(zones, zone)
+
+			// Store into map how many times this name has been used. There can
+			// be e.g. multiple "dram" instances without any index postfix. The
+			// count is then used for indexing
+			countNameUsages[name] = index + 1
+		}
+	}
+
+	return zones, nil
+}
+
+// GetEnergyMicrojoules returns the current microjoule value from the zone energy counter
+// https://www.kernel.org/doc/Documentation/power/powercap/powercap.txt
+func (rz RaplZone) GetEnergyMicrojoules() (uint64, error) {
+	return util.ReadUintFromFile(filepath.Join(rz.Path, "/energy_uj"))
+}
+
+// getIndexAndName returns a pair of (index, name) for a given name and name
+// counting map. Some RAPL-names have an index at the end, some have duplicates
+// without an index at the end. When the index is embedded in the name, it is
+// provided back as an integer, and stripped from the returned name. Usage
+// count is used when the index value is absent from the name.
+func getIndexAndName(countNameUsages map[string]int, name string) (int, string) {
+	s := strings.Split(name, "-")
+	if len(s) == 2 {
+		index, err := strconv.Atoi(s[1])
+		if err == nil {
+			return index, s[0]
+		}
+	}
+	// return count as the index, since name didn't have an index at the end
+	return countNameUsages[name], name
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_scsitape.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_scsitape.go
@@ -1,0 +1,141 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const scsiTapeClassPath = "class/scsi_tape"
+
+type SCSITapeCounters struct {
+	WriteNs      uint64 // /sys/class/scsi_tape/<Name>/stats/write_ns
+	ReadByteCnt  uint64 // /sys/class/scsi_tape/<Name>/stats/read_byte_cnt
+	IoNs         uint64 // /sys/class/scsi_tape/<Name>/stats/io_ns
+	WriteCnt     uint64 // /sys/class/scsi_tape/<Name>/stats/write_cnt
+	ResidCnt     uint64 // /sys/class/scsi_tape/<Name>/stats/resid_cnt
+	ReadNs       uint64 // /sys/class/scsi_tape/<Name>/stats/read_ns
+	InFlight     uint64 // /sys/class/scsi_tape/<Name>/stats/in_flight
+	OtherCnt     uint64 // /sys/class/scsi_tape/<Name>/stats/other_cnt
+	ReadCnt      uint64 // /sys/class/scsi_tape/<Name>/stats/read_cnt
+	WriteByteCnt uint64 // /sys/class/scsi_tape/<Name>/stats/write_byte_cnt
+}
+
+type SCSITape struct {
+	Name     string           // /sys/class/scsi_tape/<Name>
+	Counters SCSITapeCounters // /sys/class/scsi_tape/<Name>/statistics/*
+}
+
+type SCSITapeClass map[string]SCSITape
+
+// SCSITapeClass parses st[0-9]+ devices in /sys/class/scsi_tape.
+func (fs FS) SCSITapeClass() (SCSITapeClass, error) {
+	path := fs.sys.Path(scsiTapeClassPath)
+
+	dirs, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// There are n?st[0-9]+[a-b]? variants depending on device features.
+	// n/2 is probably overestimated but never underestimated
+	stc := make(SCSITapeClass, len(dirs)/2)
+	validDevice := regexp.MustCompile(`^st[0-9]+$`)
+
+	for _, d := range dirs {
+		if !validDevice.Match([]byte(d.Name())) {
+			continue
+		}
+		tape, err := fs.parseSCSITape(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		stc[tape.Name] = *tape
+	}
+
+	return stc, nil
+}
+
+// Parse a single scsi_tape.
+func (fs FS) parseSCSITape(name string) (*SCSITape, error) {
+	path := fs.sys.Path(scsiTapeClassPath, name)
+	tape := SCSITape{Name: name}
+
+	counters, err := parseSCSITapeStatistics(path)
+	if err != nil {
+		return nil, err
+	}
+	tape.Counters = *counters
+
+	return &tape, nil
+}
+
+// parseSCSITapeStatistics parses metrics from a single tape.
+func parseSCSITapeStatistics(tapePath string) (*SCSITapeCounters, error) {
+	var counters SCSITapeCounters
+
+	path := filepath.Join(tapePath, "stats")
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range files {
+		name := filepath.Join(path, f.Name())
+		value, err := util.SysReadFile(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+		}
+
+		vp := util.NewValueParser(value)
+		switch f.Name() {
+		case "in_flight":
+			counters.InFlight = *vp.PUInt64()
+		case "io_ns":
+			counters.IoNs = *vp.PUInt64()
+		case "other_cnt":
+			counters.OtherCnt = *vp.PUInt64()
+		case "read_byte_cnt":
+			counters.ReadByteCnt = *vp.PUInt64()
+		case "read_cnt":
+			counters.ReadCnt = *vp.PUInt64()
+		case "read_ns":
+			counters.ReadNs = *vp.PUInt64()
+		case "resid_cnt":
+			counters.ResidCnt = *vp.PUInt64()
+		case "write_byte_cnt":
+			counters.WriteByteCnt = *vp.PUInt64()
+		case "write_cnt":
+			counters.WriteCnt = *vp.PUInt64()
+		case "write_ns":
+			counters.WriteNs = *vp.PUInt64()
+		}
+
+		if err := vp.Err(); err != nil {
+			return nil, err
+		}
+
+	}
+
+	return &counters, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/class_thermal.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/class_thermal.go
@@ -1,0 +1,102 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// ClassThermalZoneStats contains info from files in /sys/class/thermal/thermal_zone<zone>
+// for a single <zone>.
+// https://www.kernel.org/doc/Documentation/thermal/sysfs-api.txt
+type ClassThermalZoneStats struct {
+	Name    string  // The name of the zone from the directory structure.
+	Type    string  // The type of thermal zone.
+	Temp    int64   // Temperature in millidegree Celsius.
+	Policy  string  // One of the various thermal governors used for a particular zone.
+	Mode    *bool   // Optional: One of the predefined values in [enabled, disabled].
+	Passive *uint64 // Optional: millidegrees Celsius. (0 for disabled, > 1000 for enabled+value)
+}
+
+// ClassThermalZoneStats returns Thermal Zone metrics for all zones.
+func (fs FS) ClassThermalZoneStats() ([]ClassThermalZoneStats, error) {
+	zones, err := filepath.Glob(fs.sys.Path("class/thermal/thermal_zone[0-9]*"))
+	if err != nil {
+		return nil, err
+	}
+
+	stats := make([]ClassThermalZoneStats, 0, len(zones))
+	for _, zone := range zones {
+		zoneStats, err := parseClassThermalZone(zone)
+		if err != nil {
+			if errors.Is(err, syscall.ENODATA) {
+				continue
+			}
+			return nil, err
+		}
+		zoneStats.Name = strings.TrimPrefix(filepath.Base(zone), "thermal_zone")
+		stats = append(stats, zoneStats)
+	}
+	return stats, nil
+}
+
+func parseClassThermalZone(zone string) (ClassThermalZoneStats, error) {
+	// Required attributes.
+	zoneType, err := util.SysReadFile(filepath.Join(zone, "type"))
+	if err != nil {
+		return ClassThermalZoneStats{}, err
+	}
+	zonePolicy, err := util.SysReadFile(filepath.Join(zone, "policy"))
+	if err != nil {
+		return ClassThermalZoneStats{}, err
+	}
+	zoneTemp, err := util.ReadIntFromFile(filepath.Join(zone, "temp"))
+	if err != nil {
+		return ClassThermalZoneStats{}, err
+	}
+
+	// Optional attributes.
+	mode, err := util.SysReadFile(filepath.Join(zone, "mode"))
+	if err != nil && !os.IsNotExist(err) && !os.IsPermission(err) {
+		return ClassThermalZoneStats{}, err
+	}
+	zoneMode := util.ParseBool(mode)
+
+	var zonePassive *uint64
+	passive, err := util.ReadUintFromFile(filepath.Join(zone, "passive"))
+	if os.IsNotExist(err) || os.IsPermission(err) {
+		zonePassive = nil
+	} else if err != nil {
+		return ClassThermalZoneStats{}, err
+	} else {
+		zonePassive = &passive
+	}
+
+	return ClassThermalZoneStats{
+		Type:    zoneType,
+		Policy:  zonePolicy,
+		Temp:    zoneTemp,
+		Mode:    zoneMode,
+		Passive: zonePassive,
+	}, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/clocksource.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/clocksource.go
@@ -1,0 +1,77 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// ClockSource contains metrics related to the clock source.
+type ClockSource struct {
+	Name      string
+	Available []string
+	Current   string
+}
+
+// ClockSources returns clocksource information including current and available clocksources
+// read from '/sys/devices/system/clocksource'.
+func (fs FS) ClockSources() ([]ClockSource, error) {
+
+	clocksourcePaths, err := filepath.Glob(fs.sys.Path("devices/system/clocksource/clocksource[0-9]*"))
+	if err != nil {
+		return nil, err
+	}
+
+	clocksources := make([]ClockSource, len(clocksourcePaths))
+	for i, clocksourcePath := range clocksourcePaths {
+		clocksourceName := strings.TrimPrefix(filepath.Base(clocksourcePath), "clocksource")
+
+		clocksource, err := parseClocksource(clocksourcePath)
+		if err != nil {
+			return nil, err
+		}
+		clocksource.Name = clocksourceName
+		clocksources[i] = *clocksource
+	}
+
+	return clocksources, nil
+}
+
+func parseClocksource(clocksourcePath string) (*ClockSource, error) {
+
+	stringFiles := []string{
+		"available_clocksource",
+		"current_clocksource",
+	}
+	stringOut := make([]string, len(stringFiles))
+	var err error
+
+	for i, f := range stringFiles {
+		stringOut[i], err = util.SysReadFile(filepath.Join(clocksourcePath, f))
+		if err != nil {
+			return &ClockSource{}, err
+		}
+	}
+
+	return &ClockSource{
+		Available: strings.Fields(stringOut[0]),
+		Current:   stringOut[1],
+	}, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/doc.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+// Package sysfs provides functions to retrieve system and kernel metrics
+// from the pseudo-filesystem sys.
+package sysfs

--- a/vendor/github.com/prometheus/procfs/sysfs/fs.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/fs.go
@@ -1,0 +1,46 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"github.com/prometheus/procfs/internal/fs"
+)
+
+// FS represents the pseudo-filesystem sys, which provides an interface to
+// kernel data structures.
+type FS struct {
+	sys fs.FS
+}
+
+// DefaultMountPoint is the common mount point of the sys filesystem.
+const DefaultMountPoint = fs.DefaultSysMountPoint
+
+// NewDefaultFS returns a new FS mounted under the default mountPoint. It will error
+// if the mount point can't be read.
+func NewDefaultFS() (FS, error) {
+	return NewFS(DefaultMountPoint)
+}
+
+// NewFS returns a new FS mounted under the given mountPoint. It will error
+// if the mount point can't be read.
+func NewFS(mountPoint string) (FS, error) {
+	fs, err := fs.NewFS(mountPoint)
+	if err != nil {
+		return FS{}, err
+	}
+	return FS{fs}, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/net_class.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/net_class.go
@@ -1,0 +1,199 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const netclassPath = "class/net"
+
+// NetClassIface contains info from files in /sys/class/net/<iface>
+// for single interface (iface).
+type NetClassIface struct {
+	Name             string // Interface name
+	AddrAssignType   *int64 // /sys/class/net/<iface>/addr_assign_type
+	AddrLen          *int64 // /sys/class/net/<iface>/addr_len
+	Address          string // /sys/class/net/<iface>/address
+	Broadcast        string // /sys/class/net/<iface>/broadcast
+	Carrier          *int64 // /sys/class/net/<iface>/carrier
+	CarrierChanges   *int64 // /sys/class/net/<iface>/carrier_changes
+	CarrierUpCount   *int64 // /sys/class/net/<iface>/carrier_up_count
+	CarrierDownCount *int64 // /sys/class/net/<iface>/carrier_down_count
+	DevID            *int64 // /sys/class/net/<iface>/dev_id
+	Dormant          *int64 // /sys/class/net/<iface>/dormant
+	Duplex           string // /sys/class/net/<iface>/duplex
+	Flags            *int64 // /sys/class/net/<iface>/flags
+	IfAlias          string // /sys/class/net/<iface>/ifalias
+	IfIndex          *int64 // /sys/class/net/<iface>/ifindex
+	IfLink           *int64 // /sys/class/net/<iface>/iflink
+	LinkMode         *int64 // /sys/class/net/<iface>/link_mode
+	MTU              *int64 // /sys/class/net/<iface>/mtu
+	NameAssignType   *int64 // /sys/class/net/<iface>/name_assign_type
+	NetDevGroup      *int64 // /sys/class/net/<iface>/netdev_group
+	OperState        string // /sys/class/net/<iface>/operstate
+	PhysPortID       string // /sys/class/net/<iface>/phys_port_id
+	PhysPortName     string // /sys/class/net/<iface>/phys_port_name
+	PhysSwitchID     string // /sys/class/net/<iface>/phys_switch_id
+	Speed            *int64 // /sys/class/net/<iface>/speed
+	TxQueueLen       *int64 // /sys/class/net/<iface>/tx_queue_len
+	Type             *int64 // /sys/class/net/<iface>/type
+}
+
+// NetClass is collection of info for every interface (iface) in /sys/class/net. The map keys
+// are interface (iface) names.
+type NetClass map[string]NetClassIface
+
+// NetClassDevices scans /sys/class/net for devices and returns them as a list of names.
+func (fs FS) NetClassDevices() ([]string, error) {
+	var res []string
+	path := fs.sys.Path(netclassPath)
+
+	devices, err := os.ReadDir(path)
+	if err != nil {
+		return res, fmt.Errorf("cannot access dir %q: %w", path, err)
+	}
+
+	for _, deviceDir := range devices {
+		if deviceDir.Type().IsRegular() {
+			continue
+		}
+		res = append(res, deviceDir.Name())
+	}
+
+	return res, nil
+}
+
+// NetClassByIface returns info for a single net interfaces (iface).
+func (fs FS) NetClassByIface(devicePath string) (*NetClassIface, error) {
+	path := fs.sys.Path(netclassPath)
+
+	interfaceClass, err := parseNetClassIface(filepath.Join(path, devicePath))
+	if err != nil {
+		return nil, err
+	}
+	interfaceClass.Name = devicePath
+
+	return interfaceClass, nil
+}
+
+// NetClass returns info for all net interfaces (iface) read from /sys/class/net/<iface>.
+func (fs FS) NetClass() (NetClass, error) {
+	devices, err := fs.NetClassDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	path := fs.sys.Path(netclassPath)
+	netClass := NetClass{}
+	for _, devicePath := range devices {
+		interfaceClass, err := parseNetClassIface(filepath.Join(path, devicePath))
+		if err != nil {
+			return nil, err
+		}
+		interfaceClass.Name = devicePath
+		netClass[devicePath] = *interfaceClass
+	}
+
+	return netClass, nil
+}
+
+// parseNetClassIface scans predefined files in /sys/class/net/<iface>
+// directory and gets their contents.
+func parseNetClassIface(devicePath string) (*NetClassIface, error) {
+	interfaceClass := NetClassIface{}
+
+	files, err := os.ReadDir(devicePath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range files {
+		if !f.Type().IsRegular() {
+			continue
+		}
+		name := filepath.Join(devicePath, f.Name())
+		value, err := util.SysReadFile(name)
+		if err != nil {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+		}
+		vp := util.NewValueParser(value)
+		switch f.Name() {
+		case "addr_assign_type":
+			interfaceClass.AddrAssignType = vp.PInt64()
+		case "addr_len":
+			interfaceClass.AddrLen = vp.PInt64()
+		case "address":
+			interfaceClass.Address = value
+		case "broadcast":
+			interfaceClass.Broadcast = value
+		case "carrier":
+			interfaceClass.Carrier = vp.PInt64()
+		case "carrier_changes":
+			interfaceClass.CarrierChanges = vp.PInt64()
+		case "carrier_up_count":
+			interfaceClass.CarrierUpCount = vp.PInt64()
+		case "carrier_down_count":
+			interfaceClass.CarrierDownCount = vp.PInt64()
+		case "dev_id":
+			interfaceClass.DevID = vp.PInt64()
+		case "dormant":
+			interfaceClass.Dormant = vp.PInt64()
+		case "duplex":
+			interfaceClass.Duplex = value
+		case "flags":
+			interfaceClass.Flags = vp.PInt64()
+		case "ifalias":
+			interfaceClass.IfAlias = value
+		case "ifindex":
+			interfaceClass.IfIndex = vp.PInt64()
+		case "iflink":
+			interfaceClass.IfLink = vp.PInt64()
+		case "link_mode":
+			interfaceClass.LinkMode = vp.PInt64()
+		case "mtu":
+			interfaceClass.MTU = vp.PInt64()
+		case "name_assign_type":
+			interfaceClass.NameAssignType = vp.PInt64()
+		case "netdev_group":
+			interfaceClass.NetDevGroup = vp.PInt64()
+		case "operstate":
+			interfaceClass.OperState = value
+		case "phys_port_id":
+			interfaceClass.PhysPortID = value
+		case "phys_port_name":
+			interfaceClass.PhysPortName = value
+		case "phys_switch_id":
+			interfaceClass.PhysSwitchID = value
+		case "speed":
+			interfaceClass.Speed = vp.PInt64()
+		case "tx_queue_len":
+			interfaceClass.TxQueueLen = vp.PInt64()
+		case "type":
+			interfaceClass.Type = vp.PInt64()
+		}
+	}
+
+	return &interfaceClass, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/system_cpu.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/system_cpu.go
@@ -1,0 +1,288 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// CPU represents a path to a CPU located in `/sys/devices/system/cpu/cpu[0-9]*`.
+type CPU string
+
+// Number returns the ID number of the given CPU.
+func (c CPU) Number() string {
+	return strings.TrimPrefix(filepath.Base(string(c)), "cpu")
+}
+
+// CPUTopology contains data located in `/sys/devices/system/cpu/cpu[0-9]*/topology`.
+type CPUTopology struct {
+	CoreID             string
+	CoreSiblingsList   string
+	PhysicalPackageID  string
+	ThreadSiblingsList string
+}
+
+// CPUThermalThrottle contains data from `/sys/devices/system/cpu/cpu[0-9]*/thermal_throttle`.
+type CPUThermalThrottle struct {
+	CoreThrottleCount    uint64
+	PackageThrottleCount uint64
+}
+
+// SystemCPUCpufreqStats contains stats from `/sys/devices/system/cpu/cpu[0-9]*/cpufreq/...`.
+type SystemCPUCpufreqStats struct {
+	Name                     string
+	CpuinfoCurrentFrequency  *uint64
+	CpuinfoMinimumFrequency  *uint64
+	CpuinfoMaximumFrequency  *uint64
+	CpuinfoTransitionLatency *uint64
+	ScalingCurrentFrequency  *uint64
+	ScalingMinimumFrequency  *uint64
+	ScalingMaximumFrequency  *uint64
+	AvailableGovernors       string
+	Driver                   string
+	Governor                 string
+	RelatedCpus              string
+	SetSpeed                 string
+}
+
+// CPUs returns a slice of all CPUs in `/sys/devices/system/cpu`.
+func (fs FS) CPUs() ([]CPU, error) {
+	cpuPaths, err := filepath.Glob(fs.sys.Path("devices/system/cpu/cpu[0-9]*"))
+	if err != nil {
+		return nil, err
+	}
+	cpus := make([]CPU, len(cpuPaths))
+	for i, cpu := range cpuPaths {
+		cpus[i] = CPU(cpu)
+	}
+	return cpus, nil
+}
+
+// Topology gets the topology information for a single CPU from `/sys/devices/system/cpu/cpuN/topology`.
+func (c CPU) Topology() (*CPUTopology, error) {
+	cpuTopologyPath := filepath.Join(string(c), "topology")
+	if _, err := os.Stat(cpuTopologyPath); err != nil {
+		return nil, err
+	}
+	t, err := parseCPUTopology(cpuTopologyPath)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func parseCPUTopology(cpuPath string) (*CPUTopology, error) {
+	t := CPUTopology{}
+	var err error
+	t.CoreID, err = util.SysReadFile(filepath.Join(cpuPath, "core_id"))
+	if err != nil {
+		return nil, err
+	}
+	t.PhysicalPackageID, err = util.SysReadFile(filepath.Join(cpuPath, "physical_package_id"))
+	if err != nil {
+		return nil, err
+	}
+	t.CoreSiblingsList, err = util.SysReadFile(filepath.Join(cpuPath, "core_siblings_list"))
+	if err != nil {
+		return nil, err
+	}
+	t.ThreadSiblingsList, err = util.SysReadFile(filepath.Join(cpuPath, "thread_siblings_list"))
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// ThermalThrottle gets the cpu throttle count information for a single CPU from `/sys/devices/system/cpu/cpuN/thermal_throttle`.
+func (c CPU) ThermalThrottle() (*CPUThermalThrottle, error) {
+	cpuPath := filepath.Join(string(c), "thermal_throttle")
+	if _, err := os.Stat(cpuPath); err != nil {
+		return nil, err
+	}
+	t, err := parseCPUThermalThrottle(cpuPath)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func parseCPUThermalThrottle(cpuPath string) (*CPUThermalThrottle, error) {
+	t := CPUThermalThrottle{}
+	var err error
+	t.PackageThrottleCount, err = util.ReadUintFromFile(filepath.Join(cpuPath, "package_throttle_count"))
+	if err != nil {
+		return nil, err
+	}
+	t.CoreThrottleCount, err = util.ReadUintFromFile(filepath.Join(cpuPath, "core_throttle_count"))
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// SystemCpufreq returns CPU frequency metrics for all CPUs.
+func (fs FS) SystemCpufreq() ([]SystemCPUCpufreqStats, error) {
+	var g errgroup.Group
+
+	cpus, err := filepath.Glob(fs.sys.Path("devices/system/cpu/cpu[0-9]*"))
+	if err != nil {
+		return nil, err
+	}
+
+	systemCpufreq := make([]SystemCPUCpufreqStats, len(cpus))
+	for i, cpu := range cpus {
+		cpuName := strings.TrimPrefix(filepath.Base(cpu), "cpu")
+
+		cpuCpufreqPath := filepath.Join(cpu, "cpufreq")
+		_, err = os.Stat(cpuCpufreqPath)
+		if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+
+		// Execute the parsing of each CPU in parallel.
+		// This is done because the kernel intentionally delays access to each CPU by
+		// 50 milliseconds to avoid DDoSing possibly expensive functions.
+		i := i // https://golang.org/doc/faq#closures_and_goroutines
+		g.Go(func() error {
+			cpufreq, err := parseCpufreqCpuinfo(cpuCpufreqPath)
+			if err == nil {
+				cpufreq.Name = cpuName
+				systemCpufreq[i] = *cpufreq
+			}
+			return err
+		})
+	}
+
+	if err = g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return systemCpufreq, nil
+}
+
+func parseCpufreqCpuinfo(cpuPath string) (*SystemCPUCpufreqStats, error) {
+	uintFiles := []string{
+		"cpuinfo_cur_freq",
+		"cpuinfo_max_freq",
+		"cpuinfo_min_freq",
+		"cpuinfo_transition_latency",
+		"scaling_cur_freq",
+		"scaling_max_freq",
+		"scaling_min_freq",
+	}
+	uintOut := make([]*uint64, len(uintFiles))
+
+	for i, f := range uintFiles {
+		v, err := util.ReadUintFromFile(filepath.Join(cpuPath, f))
+		if err != nil {
+			if os.IsNotExist(err) || os.IsPermission(err) {
+				continue
+			}
+			return &SystemCPUCpufreqStats{}, err
+		}
+
+		uintOut[i] = &v
+	}
+
+	stringFiles := []string{
+		"scaling_available_governors",
+		"scaling_driver",
+		"scaling_governor",
+		"related_cpus",
+		"scaling_setspeed",
+	}
+	stringOut := make([]string, len(stringFiles))
+	var err error
+
+	for i, f := range stringFiles {
+		stringOut[i], err = util.SysReadFile(filepath.Join(cpuPath, f))
+		if err != nil {
+			return &SystemCPUCpufreqStats{}, err
+		}
+	}
+
+	return &SystemCPUCpufreqStats{
+		CpuinfoCurrentFrequency:  uintOut[0],
+		CpuinfoMaximumFrequency:  uintOut[1],
+		CpuinfoMinimumFrequency:  uintOut[2],
+		CpuinfoTransitionLatency: uintOut[3],
+		ScalingCurrentFrequency:  uintOut[4],
+		ScalingMaximumFrequency:  uintOut[5],
+		ScalingMinimumFrequency:  uintOut[6],
+		AvailableGovernors:       stringOut[0],
+		Driver:                   stringOut[1],
+		Governor:                 stringOut[2],
+		RelatedCpus:              stringOut[3],
+		SetSpeed:                 stringOut[4],
+	}, nil
+}
+
+func (fs FS) IsolatedCPUs() ([]uint16, error) {
+	isolcpus, err := os.ReadFile(fs.sys.Path("devices/system/cpu/isolated"))
+	if err != nil {
+		return nil, err
+	}
+
+	return parseIsolatedCPUs(isolcpus)
+}
+
+func parseIsolatedCPUs(data []byte) ([]uint16, error) {
+
+	var isolcpusInt = []uint16{}
+
+	for _, cpu := range strings.Split(strings.TrimRight(string(data), "\n"), ",") {
+		if cpu == "" {
+			continue
+		}
+		if strings.Contains(cpu, "-") {
+			ranges := strings.Split(cpu, "-")
+			if len(ranges) != 2 {
+				return nil, fmt.Errorf("invalid cpu range: %s", cpu)
+			}
+			startRange, err := strconv.Atoi(ranges[0])
+			if err != nil {
+				return nil, fmt.Errorf("invalid cpu start range: %w", err)
+			}
+			endRange, err := strconv.Atoi(ranges[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid cpu end range: %w", err)
+			}
+
+			for i := startRange; i <= endRange; i++ {
+				isolcpusInt = append(isolcpusInt, uint16(i))
+			}
+			continue
+		}
+
+		cpuN, err := strconv.Atoi(cpu)
+		if err != nil {
+			return nil, err
+		}
+		isolcpusInt = append(isolcpusInt, uint16(cpuN))
+	}
+	return isolcpusInt, nil
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/vmstat_numa.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/vmstat_numa.go
@@ -1,0 +1,249 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+var (
+	nodePattern      = "devices/system/node/node[0-9]*"
+	nodeNumberRegexp = regexp.MustCompile(`.*devices/system/node/node([0-9]*)`)
+)
+
+type VMStat struct {
+	NrFreePages                uint64
+	NrZoneInactiveAnon         uint64
+	NrZoneActiveAnon           uint64
+	NrZoneInactiveFile         uint64
+	NrZoneActiveFile           uint64
+	NrZoneUnevictable          uint64
+	NrZoneWritePending         uint64
+	NrMlock                    uint64
+	NrPageTablePages           uint64
+	NrKernelStack              uint64
+	NrBounce                   uint64
+	NrZspages                  uint64
+	NrFreeCma                  uint64
+	NumaHit                    uint64
+	NumaMiss                   uint64
+	NumaForeign                uint64
+	NumaInterleave             uint64
+	NumaLocal                  uint64
+	NumaOther                  uint64
+	NrInactiveAnon             uint64
+	NrActiveAnon               uint64
+	NrInactiveFile             uint64
+	NrActiveFile               uint64
+	NrUnevictable              uint64
+	NrSlabReclaimable          uint64
+	NrSlabUnreclaimable        uint64
+	NrIsolatedAnon             uint64
+	NrIsolatedFile             uint64
+	WorkingsetNodes            uint64
+	WorkingsetRefault          uint64
+	WorkingsetActivate         uint64
+	WorkingsetRestore          uint64
+	WorkingsetNodereclaim      uint64
+	NrAnonPages                uint64
+	NrMapped                   uint64
+	NrFilePages                uint64
+	NrDirty                    uint64
+	NrWriteback                uint64
+	NrWritebackTemp            uint64
+	NrShmem                    uint64
+	NrShmemHugepages           uint64
+	NrShmemPmdmapped           uint64
+	NrFileHugepages            uint64
+	NrFilePmdmapped            uint64
+	NrAnonTransparentHugepages uint64
+	NrVmscanWrite              uint64
+	NrVmscanImmediateReclaim   uint64
+	NrDirtied                  uint64
+	NrWritten                  uint64
+	NrKernelMiscReclaimable    uint64
+	NrFollPinAcquired          uint64
+	NrFollPinReleased          uint64
+}
+
+func (fs FS) VMStatNUMA() (map[int]VMStat, error) {
+	m := make(map[int]VMStat)
+	nodes, err := filepath.Glob(fs.sys.Path(nodePattern))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range nodes {
+		nodeNumbers := nodeNumberRegexp.FindStringSubmatch(node)
+		if len(nodeNumbers) != 2 {
+			continue
+		}
+		nodeNumber, err := strconv.Atoi(nodeNumbers[1])
+		if err != nil {
+			return nil, err
+		}
+		file, err := util.ReadFileNoStat(filepath.Join(node, "vmstat"))
+		if err != nil {
+			return nil, err
+		}
+		nodeStats, err := parseVMStatNUMA(file)
+		if err != nil {
+			return nil, err
+		}
+		m[nodeNumber] = nodeStats
+	}
+	return m, nil
+}
+
+func parseVMStatNUMA(r []byte) (VMStat, error) {
+	var (
+		vmStat  = VMStat{}
+		scanner = bufio.NewScanner(bytes.NewReader(r))
+	)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			return vmStat, fmt.Errorf("line scan did not return 2 fields: %s", line)
+		}
+
+		fv, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			return vmStat, fmt.Errorf("invalid value in vmstat: %w", err)
+		}
+		switch parts[0] {
+		case "nr_free_pages":
+			vmStat.NrFreePages = fv
+		case "nr_zone_inactive_anon":
+			vmStat.NrZoneInactiveAnon = fv
+		case "nr_zone_active_anon":
+			vmStat.NrZoneActiveAnon = fv
+		case "nr_zone_inactive_file":
+			vmStat.NrZoneActiveFile = fv
+		case "nr_zone_active_file":
+			vmStat.NrZoneActiveFile = fv
+		case "nr_zone_unevictable":
+			vmStat.NrZoneUnevictable = fv
+		case "nr_zone_write_pending":
+			vmStat.NrZoneWritePending = fv
+		case "nr_mlock":
+			vmStat.NrMlock = fv
+		case "nr_page_table_pages":
+			vmStat.NrPageTablePages = fv
+		case "nr_kernel_stack":
+			vmStat.NrKernelStack = fv
+		case "nr_bounce":
+			vmStat.NrBounce = fv
+		case "nr_zspages":
+			vmStat.NrZspages = fv
+		case "nr_free_cma":
+			vmStat.NrFreeCma = fv
+		case "numa_hit":
+			vmStat.NumaHit = fv
+		case "numa_miss":
+			vmStat.NumaMiss = fv
+		case "numa_foreign":
+			vmStat.NumaForeign = fv
+		case "numa_interleave":
+			vmStat.NumaInterleave = fv
+		case "numa_local":
+			vmStat.NumaLocal = fv
+		case "numa_other":
+			vmStat.NumaOther = fv
+		case "nr_inactive_anon":
+			vmStat.NrInactiveAnon = fv
+		case "nr_active_anon":
+			vmStat.NrActiveAnon = fv
+		case "nr_inactive_file":
+			vmStat.NrInactiveFile = fv
+		case "nr_active_file":
+			vmStat.NrActiveFile = fv
+		case "nr_unevictable":
+			vmStat.NrUnevictable = fv
+		case "nr_slab_reclaimable":
+			vmStat.NrSlabReclaimable = fv
+		case "nr_slab_unreclaimable":
+			vmStat.NrSlabUnreclaimable = fv
+		case "nr_isolated_anon":
+			vmStat.NrIsolatedAnon = fv
+		case "nr_isolated_file":
+			vmStat.NrIsolatedFile = fv
+		case "workingset_nodes":
+			vmStat.WorkingsetNodes = fv
+		case "workingset_refault":
+			vmStat.WorkingsetRefault = fv
+		case "workingset_activate":
+			vmStat.WorkingsetActivate = fv
+		case "workingset_restore":
+			vmStat.WorkingsetRestore = fv
+		case "workingset_nodereclaim":
+			vmStat.WorkingsetNodereclaim = fv
+		case "nr_anon_pages":
+			vmStat.NrAnonPages = fv
+		case "nr_mapped":
+			vmStat.NrMapped = fv
+		case "nr_file_pages":
+			vmStat.NrFilePages = fv
+		case "nr_dirty":
+			vmStat.NrDirty = fv
+		case "nr_writeback":
+			vmStat.NrWriteback = fv
+		case "nr_writeback_temp":
+			vmStat.NrWritebackTemp = fv
+		case "nr_shmem":
+			vmStat.NrShmem = fv
+		case "nr_shmem_hugepages":
+			vmStat.NrShmemHugepages = fv
+		case "nr_shmem_pmdmapped":
+			vmStat.NrShmemPmdmapped = fv
+		case "nr_file_hugepages":
+			vmStat.NrFileHugepages = fv
+		case "nr_file_pmdmapped":
+			vmStat.NrFilePmdmapped = fv
+		case "nr_anon_transparent_hugepages":
+			vmStat.NrAnonTransparentHugepages = fv
+		case "nr_vmscan_write":
+			vmStat.NrVmscanWrite = fv
+		case "nr_vmscan_immediate_reclaim":
+			vmStat.NrVmscanImmediateReclaim = fv
+		case "nr_dirtied":
+			vmStat.NrDirtied = fv
+		case "nr_written":
+			vmStat.NrWritten = fv
+		case "nr_kernel_misc_reclaimable":
+			vmStat.NrKernelMiscReclaimable = fv
+		case "nr_foll_pin_acquired":
+			vmStat.NrFollPinAcquired = fv
+		case "nr_foll_pin_released":
+			vmStat.NrFollPinReleased = fv
+		}
+
+	}
+	return vmStat, scanner.Err()
+}

--- a/vendor/github.com/prometheus/procfs/sysfs/vulnerability.go
+++ b/vendor/github.com/prometheus/procfs/sysfs/vulnerability.go
@@ -1,0 +1,87 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	notAffected = "Not Affected"
+	vulnerable  = "Vulnerable"
+	mitigation  = "Mitigation"
+)
+
+// CPUVulnerabilities retrieves a map of vulnerability names to their mitigations.
+func (fs FS) CPUVulnerabilities() ([]Vulnerability, error) {
+	matches, err := filepath.Glob(fs.sys.Path("devices/system/cpu/vulnerabilities/*"))
+	if err != nil {
+		return nil, err
+	}
+
+	vulnerabilities := make([]Vulnerability, 0, len(matches))
+	for _, match := range matches {
+		name := filepath.Base(match)
+
+		value, err := os.ReadFile(match)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := parseVulnerability(name, string(value))
+		if err != nil {
+			return nil, err
+		}
+
+		vulnerabilities = append(vulnerabilities, v)
+	}
+
+	return vulnerabilities, nil
+}
+
+// Vulnerability represents a single vulnerability extracted from /sys/devices/system/cpu/vulnerabilities/.
+type Vulnerability struct {
+	CodeName   string
+	State      string
+	Mitigation string
+}
+
+func parseVulnerability(name, value string) (Vulnerability, error) {
+	v := Vulnerability{CodeName: name}
+	value = strings.TrimSpace(value)
+	if value == notAffected {
+		v.State = notAffected
+		return v, nil
+	}
+
+	if strings.HasPrefix(value, vulnerable) {
+		v.State = vulnerable
+		v.Mitigation = strings.TrimPrefix(strings.TrimPrefix(value, vulnerable), ": ")
+		return v, nil
+	}
+
+	if strings.HasPrefix(value, mitigation) {
+		v.State = mitigation
+		v.Mitigation = strings.TrimPrefix(strings.TrimPrefix(value, mitigation), ": ")
+		return v, nil
+	}
+
+	return v, fmt.Errorf("unknown vulnerability state for %s: %s", name, value)
+}

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,132 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type token struct{}
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	sem chan token
+
+	errOnce sync.Once
+	err     error
+}
+
+func (g *Group) done() {
+	if g.sem != nil {
+		<-g.sem
+	}
+	g.wg.Done()
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
+// active goroutines in the group exceeding the configured limit.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	if g.sem != nil {
+		g.sem <- token{}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}
+
+// TryGo calls the given function in a new goroutine only if the number of
+// active goroutines in the group is currently below the configured limit.
+//
+// The return value reports whether the goroutine was started.
+func (g *Group) TryGo(f func() error) bool {
+	if g.sem != nil {
+		select {
+		case g.sem <- token{}:
+			// Note: this allows barging iff channels in general allow barging.
+		default:
+			return false
+		}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+	return true
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
+//
+// Any subsequent call to the Go method will block until it can add an active
+// goroutine without exceeding the configured limit.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (g *Group) SetLimit(n int) {
+	if n < 0 {
+		g.sem = nil
+		return
+	}
+	if len(g.sem) != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	}
+	g.sem = make(chan token, n)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -86,6 +86,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+github.com/prometheus/procfs/sysfs
 # github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 ## explicit
 github.com/rifflock/lfshook
@@ -126,6 +127,9 @@ github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.4.1
 ## explicit; go 1.18
 github.com/subosito/gotenv
+# golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+## explicit
+golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20220908164124-27713097b956
 ## explicit; go 1.17
 golang.org/x/sys/internal/unsafeheader


### PR DESCRIPTION
Periodically reports the MTU of each local network device via sysfs (github.com/prometheus/procfs/sysfs), mirroring node_exporter's netclass mtu_bytes metric. Only runs when the debug metrics endpoint is enabled.