### PR TITLE
el10 support: add discovery-client-packages-el10 build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ discovery-packages-el8: discovery-rpms-el8 discovery-client-debs
 
 discovery-packages-el9: discovery-rpms-el9 discovery-client-debs
 
+discovery-packages-el10: discovery-rpms-el10 discovery-client-debs
+
 install-discovery-client-packages-%: COMPONENT_PATH = $(shell component-tool localpath --repo=discovery-client --type=$(BUILD_TYPE) discovery-client-packages-$*)
 install-discovery-client-packages-%:
 	$(Q)mkdir -p $(COMPONENT_PATH)/
@@ -177,6 +179,7 @@ install-discovery-client:
 .PHONY: discovery-rpms-% discovery-client-debs-%\
 	discovery-packages-el8 \
 	discovery-packages-el9 \
+	discovery-packages-el10 \
 	install-discovery-client-packages-% \
 	install-discovery-client clean
 

--- a/lb.yaml
+++ b/lb.yaml
@@ -49,6 +49,23 @@ discovery-client:
     - file://go.mod
     - file://discovery-client.spec
 
+  discovery-client-packages-el10:
+    build:
+    - make discovery-packages-el10 -f Makefile.lb
+    install:
+    - make install-discovery-client-packages-el10
+    deps:
+    - milestone:milestone
+    - file://Makefile
+    - file://Makefile.lb
+    - file://pkg
+    - file://model
+    - file://vendor
+    - file://application
+    - file://main.go
+    - file://go.mod
+    - file://discovery-client.spec
+
   lb-nvme-discovery-client:
     build:
     - make -f Makefile.lb build-image


### PR DESCRIPTION
## Summary
Adds a `discovery-packages-el10` Makefile target and matching `discovery-client-packages-el10` lb.yaml entry, mirroring the existing el8/el9 targets. `discovery-client.spec` needed no distro-conditional changes.

## Depends on
Companion PRs in `systests`, `management`, `common`, `light-app`, `image-store`, `lbcitests`, `kernelight`, `discovery-service`.

Issue: LBM1-44748

Depends-On: https://github.com/LightBitsLabs/common/pull/4829
