### PR TITLE
Makefile: build discovery-client deb from a plain-release RPM (backport 3.15) (LBM1-45045)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ DISCOVERY_CLIENT_PKG=github.com/lightbitslabs/discovery-client
 
 DSC_IMG := $(DOCKER_REGISTRY)$(DOCKER_TAG)
 RPMOUT_DIR := $(WORKSPACE_TOP)/discovery-client/build/dist
+# Dedicated output dir for the RPM that backs the .deb, so its plain "-1" release
+# does not collide with the hash-tagged release RPM in RPMOUT_DIR (LBM1-45045).
+DEB_RPMOUT_DIR := $(WORKSPACE_TOP)/discovery-client/build/deb-dist
 
 override GO_VARS := GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOFLAGS=-mod=vendor
 
@@ -74,8 +77,11 @@ discovery-rpms: build/dist build/discovery-client
 	$(Q) rm -rf ${RPMOUT_DIR}
 	$(Q) rpmbuild -bb --clean --define="version ${VERSION}" --define="_builddir `pwd`" --define="dist $(DISCOVERY_CLIENT_RELEASE)~$(MANIFEST_HASH_VERSION)" --define "_rpmdir $(RPMOUT_DIR)" discovery-client.spec
 
+discovery-client-debs: VERSION = $(or $(LIGHTOS_VERSION),$(DEFAULT_REL))
 discovery-client-debs: discovery-rpms
-	(cd build/dist && sudo alien --to-deb -v -k ${RPMOUT_DIR}/x86_64/discovery-client*.rpm && sudo chown ${USER}:${USER} ${WORKSPACE_TOP}/discovery-client/build/dist/*.deb)
+	$(Q) rm -rf $(DEB_RPMOUT_DIR)
+	$(Q) rpmbuild -bb --clean --define="version ${VERSION}" --define="_builddir `pwd`" --define="dist $(DISCOVERY_CLIENT_RELEASE)" --define "_rpmdir $(DEB_RPMOUT_DIR)" discovery-client.spec
+	(cd build/dist && sudo alien --to-deb -v -k $(DEB_RPMOUT_DIR)/x86_64/discovery-client-${VERSION}-${DISCOVERY_CLIENT_RELEASE}.x86_64.rpm && sudo chown ${USER}:${USER} ${WORKSPACE_TOP}/discovery-client/build/dist/*.deb)
 
 discovery-packages: discovery-rpms discovery-client-debs
 


### PR DESCRIPTION
Backport (adapted) of #56 / #61 to `Lightbits_3_15_branch`, for LBM1-45045.

### Problem
On the 3.15 line the release RPM is built with `dist = $(DISCOVERY_CLIENT_RELEASE)~$(MANIFEST_HASH_VERSION)`, and the `.deb` was produced by `alien`'ing that same RPM (globbed). So the deb name inherited the manifest-hash suffix:

```
discovery-client_<ver>-1~<hash>_amd64.deb      # actual
discovery-client_<ver>-1_amd64.deb             # wanted
```

This is the `~<hash>` naming symptom reported in LBM1-45045 (3.18.2). Note the 3.15 Makefile is structurally different from `main`/3.18 — it has **no el8/el9 split** — so #56 does not cherry-pick cleanly and the `.el8`/`.el9` variant of the bug does not apply here.

### Fix (mirrors #56's intent, adapted to 3.15)
- Build a **dedicated RPM for the deb** with a plain `-1` release (no `~<hash>`) into a separate `DEB_RPMOUT_DIR`, so it doesn't collide with the hash-tagged release RPM in `RPMOUT_DIR`.
- `alien` the exact dedicated RPM by name instead of globbing.
- Release RPM and `install-discovery-client-packages` glob are untouched — **only the `.deb` name changes**.

On `main`/3.18 the equivalent change dropped the tag from the deb name and has shipped since June/July without issue.

### ⚠️ Needs a build validation before merge
I could not run an actual `make discovery-client-debs` build in this environment. Please confirm on a runner that:
1. the deb is produced as `discovery-client_<ver>-1_amd64.deb`, and
2. nothing in the 3.15 release/lbrepo-upload tooling globs for the old `~<hash>` deb name.

3.15 is **not** listed in LBM1-45045's fixVersions (3.20.1 / affects 3.18.2) — this is proactive LTS hardening.

Issue: LBM1-45045